### PR TITLE
fix: allow Schema value import

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Use in code:
 
 ```ts
 import { onyx, eq, asc } from '@onyx.dev/onyx-database';
-import { tables, type Schema } from './src/onyx/types';
+import { tables, Schema } from './src/onyx/types';
 
 const db = onyx.init<Schema>();
 

--- a/changelog/2025-08-24-0254am-schema-value-export.md
+++ b/changelog/2025-08-24-0254am-schema-value-export.md
@@ -1,0 +1,14 @@
+# Change: expose Schema as value for easier imports
+
+- Date: 2025-08-24 02:54 AM PT
+- Author/Agent: OpenAI Assistant
+- Scope: gen | examples | docs
+- Type: fix
+- Summary:
+  - export a runtime `Schema` constant from generated types
+  - drop `type` qualifier in example imports
+  - document new import style
+- Impact:
+  - enables `import { Schema }` without TypeScript type-only syntax
+- Follow-ups:
+  - none

--- a/examples/query/basic.ts
+++ b/examples/query/basic.ts
@@ -1,7 +1,7 @@
 // filename: examples/query/basic.ts
 import process from 'node:process';
 import { onyx, eq, gt } from '@onyx.dev/onyx-database';
-import { tables, type Schema } from 'onyx/types';
+import { tables, Schema } from 'onyx/types';
 
 async function main(): Promise<void> {
   const db = onyx.init<Schema>();

--- a/examples/query/resolver.ts
+++ b/examples/query/resolver.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import { onyx, eq, gt } from '@onyx.dev/onyx-database';
-import { tables, type Schema } from 'onyx/types';
+import { tables, Schema } from 'onyx/types';
 
 async function main(): Promise<void> {
   const db = onyx.init<Schema>();

--- a/examples/save/basic.ts
+++ b/examples/save/basic.ts
@@ -1,7 +1,7 @@
 // filename: examples/save/basic.ts
 import process from 'node:process';
 import { onyx, eq, gt } from '@onyx.dev/onyx-database';
-import { tables, type Schema } from 'onyx/types';
+import { tables, Schema } from 'onyx/types';
 
 async function main(): Promise<void> {
   const db = onyx.init<Schema>();

--- a/gen/emit.ts
+++ b/gen/emit.ts
@@ -154,8 +154,9 @@ export function emitTypes(schema: OnyxIntrospection, options?: EmitOptions): str
   // Convenience alias so consumers can always `import { Schema }`
   if (opts.schemaTypeName !== 'Schema') {
     lines.push(`export type Schema = ${opts.schemaTypeName};`);
-    lines.push('');
   }
+  lines.push(`export const Schema = {} as ${opts.schemaTypeName};`);
+  lines.push('');
 
   // Tables enum (for IDE suggestions & safer table refs)
   lines.push('export enum tables {');


### PR DESCRIPTION
## Summary
- export a runtime `Schema` constant from generated types
- drop `type` qualifiers from example imports
- document new `Schema` import style

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test` *(fails: No test files found)*
- `npm --prefix examples run gen:onyx`
- `npx tsx query/basic.ts` *(fails: missing Onyx config)*


------
https://chatgpt.com/codex/tasks/task_e_68aa7e5fb1fc8321bf5f2910ef31a192