### PR TITLE
docs: add testing setup plan

### DIFF
--- a/changelog/2025-08-23-0824pm-plan-testing-setup.md
+++ b/changelog/2025-08-23-0824pm-plan-testing-setup.md
@@ -1,0 +1,13 @@
+# Change: add plan for testing setup
+
+- Date: 2025-08-23 08:24 PM PT
+- Author/Agent: openai-assistant
+- Scope: docs
+- Type: docs
+- Summary:
+  - Added plan outlining steps for Vitest testing setup
+  - Marked task 004 as in-progress in progress tracker
+- Impact:
+  - no code changes
+- Follow-ups:
+  - implement testing setup and update task status

--- a/codex/tasks/_progress.json
+++ b/codex/tasks/_progress.json
@@ -1,26 +1,146 @@
 {
   "version": 1,
-  "updatedAt": "2025-08-24T03:09:46Z",
+  "updatedAt": "2025-08-24T03:24:19Z",
   "tasks": [
-    { "id": "001-init-repo", "file": "library-readiness/finished/001-init-repo.md", "status": "done", "assignee": "", "notes": "" },
-    { "id": "002-typescript-config", "file": "library-readiness/finished/002-typescript-config.md", "status": "done", "assignee": "", "notes": "" },
-    { "id": "003-lint-format", "file": "library-readiness/finished/003-lint-format.md", "status": "done", "assignee": "", "notes": "" },
-    { "id": "004-testing-setup", "file": "library-readiness/004-testing-setup.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "005-build-bundle", "file": "library-readiness/finished/005-build-bundle.md", "status": "done", "assignee": "", "notes": "" },
-    { "id": "006-dual-module-exports", "file": "library-readiness/finished/006-dual-module-exports.md", "status": "done", "assignee": "", "notes": "" },
-    { "id": "007-typedoc-docs", "file": "library-readiness/007-typedoc-docs.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "008-examples-setup", "file": "library-readiness/finished/008-examples-setup.md", "status": "done", "assignee": "", "notes": "" },
-    { "id": "009-ci-workflows", "file": "library-readiness/009-ci-workflows.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "010-release-automation", "file": "library-readiness/010-release-automation.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "011-security-audit", "file": "library-readiness/011-security-audit.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "012-contributing-templates", "file": "library-readiness/012-contributing-templates.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "013-license-and-notices", "file": "library-readiness/013-license-and-notices.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "014-package-json-hygiene", "file": "library-readiness/014-package-json-hygiene.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "015-tree-shaking-size-check", "file": "library-readiness/015-tree-shaking-size-check.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "016-peer-deps-compat", "file": "library-readiness/016-peer-deps-compat.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "017-esm-cjs-interop-tests", "file": "library-readiness/017-esm-cjs-interop-tests.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "018-types-validation-tests", "file": "library-readiness/018-types-validation-tests.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "019-smoke-example-tests", "file": "library-readiness/019-smoke-example-tests.md", "status": "todo", "assignee": "", "notes": "" },
-    { "id": "020-publish-dry-run", "file": "library-readiness/020-publish-dry-run.md", "status": "todo", "assignee": "", "notes": "" }
+    {
+      "id": "001-init-repo",
+      "file": "library-readiness/finished/001-init-repo.md",
+      "status": "done",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "002-typescript-config",
+      "file": "library-readiness/finished/002-typescript-config.md",
+      "status": "done",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "003-lint-format",
+      "file": "library-readiness/finished/003-lint-format.md",
+      "status": "done",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "004-testing-setup",
+      "file": "library-readiness/004-testing-setup.md",
+      "status": "in-progress",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "005-build-bundle",
+      "file": "library-readiness/finished/005-build-bundle.md",
+      "status": "done",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "006-dual-module-exports",
+      "file": "library-readiness/finished/006-dual-module-exports.md",
+      "status": "done",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "007-typedoc-docs",
+      "file": "library-readiness/007-typedoc-docs.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "008-examples-setup",
+      "file": "library-readiness/finished/008-examples-setup.md",
+      "status": "done",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "009-ci-workflows",
+      "file": "library-readiness/009-ci-workflows.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "010-release-automation",
+      "file": "library-readiness/010-release-automation.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "011-security-audit",
+      "file": "library-readiness/011-security-audit.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "012-contributing-templates",
+      "file": "library-readiness/012-contributing-templates.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "013-license-and-notices",
+      "file": "library-readiness/013-license-and-notices.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "014-package-json-hygiene",
+      "file": "library-readiness/014-package-json-hygiene.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "015-tree-shaking-size-check",
+      "file": "library-readiness/015-tree-shaking-size-check.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "016-peer-deps-compat",
+      "file": "library-readiness/016-peer-deps-compat.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "017-esm-cjs-interop-tests",
+      "file": "library-readiness/017-esm-cjs-interop-tests.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "018-types-validation-tests",
+      "file": "library-readiness/018-types-validation-tests.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "019-smoke-example-tests",
+      "file": "library-readiness/019-smoke-example-tests.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    },
+    {
+      "id": "020-publish-dry-run",
+      "file": "library-readiness/020-publish-dry-run.md",
+      "status": "todo",
+      "assignee": "",
+      "notes": ""
+    }
   ]
 }

--- a/codex/tasks/library-readiness/plan/004-testing-setup-plan.md
+++ b/codex/tasks/library-readiness/plan/004-testing-setup-plan.md
@@ -1,0 +1,11 @@
+# Plan: Testing with Vitest + ts-node support
+
+1. Install `vitest`, `@vitest/coverage-v8`, and `ts-node` as dev dependencies.
+2. Create `vitest.config.ts` with TypeScript support via ts-node and include `src` for coverage.
+3. Add `tests/basic.spec.ts` with a simple assertion against an exported function.
+4. Update `package.json` scripts with `"test": "vitest run"` and `"test:watch": "vitest"`.
+5. Run `npm test` to verify execution and coverage output.
+
+## Acceptance Criteria
+- [ ] `npm test` passes and writes coverage summary.
+- [ ] Coverage includes lines, functions, and branches for `src/`.


### PR DESCRIPTION
## Summary
- add plan for setting up Vitest with ts-node
- mark testing setup task in progress

## Testing
- `npm run typecheck`
- `npm test` *(fails: No test files found, exiting with code 1)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa85aa7de88321a01d731124c78b9e