### PR TITLE
test: cover HttpClient with mocked fetch

### DIFF
--- a/changelog/2025-08-23-0840pm-vitest-setup.md
+++ b/changelog/2025-08-23-0840pm-vitest-setup.md
@@ -1,0 +1,14 @@
+# Change: set up Vitest with coverage
+
+- Date: 2025-08-23 08:40 PM PT
+- Author/Agent: OpenAI Assistant
+- Scope: tooling
+- Type: test
+- Summary:
+  - add Vitest configuration with coverage enabled
+  - add basic spec validating onyx init export
+  - install coverage and ts-node dependencies
+- Impact:
+  - no runtime or public API changes
+- Follow-ups:
+  - expand test coverage

--- a/changelog/2025-08-23-0910pm-http-client-tests.md
+++ b/changelog/2025-08-23-0910pm-http-client-tests.md
@@ -1,0 +1,13 @@
+# Change: add HttpClient tests using mocks
+
+- Date: 2025-08-23 09:10 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: test
+- Summary:
+  - add tests for HttpClient and JSON parser using mocked fetch
+  - increase coverage for success and error cases
+- Impact:
+  - no public API changes
+- Follow-ups:
+  - none

--- a/changelog/2025-08-24-0350am-codecov-coverage.md
+++ b/changelog/2025-08-24-0350am-codecov-coverage.md
@@ -1,0 +1,13 @@
+# Change: add lcov reporter and full coverage for core errors
+
+- Date: 2025-08-24 03:50 AM UTC
+- Author/Agent: ChatGPT
+- Scope: tooling
+- Type: test
+- Summary:
+  - enable lcov reporter for Codecov
+  - cover HttpClient and OnyxConfigError to 100%
+- Impact:
+  none
+- Follow-ups:
+  none

--- a/codex/tasks/library-readiness/finished/001-testing-setup.md
+++ b/codex/tasks/library-readiness/finished/001-testing-setup.md
@@ -20,5 +20,5 @@ Unit tests with Vitest and coverage.
 5. Run `npm test` to verify execution and coverage output.
 
 ## Acceptance Criteria
-- [ ] `npm test` passes and writes coverage summary.
-- [ ] Coverage includes lines, functions, and branches for `src/`.
+- [x] `npm test` passes and writes coverage summary.
+- [x] Coverage includes lines, functions, and branches for `src/`.

--- a/codex/tasks/library-readiness/finished/015-http-client-tests.md
+++ b/codex/tasks/library-readiness/finished/015-http-client-tests.md
@@ -1,0 +1,18 @@
+# Task: Add HttpClient tests with mocks
+
+## Goal
+Increase coverage for HttpClient and JSON parsing using mocked fetch implementations.
+
+## Steps
+1. Write tests for `parseJsonAllowNaN` to ensure it handles `NaN` and `Infinity` values.
+2. Mock `fetch` to test `HttpClient.request` success path and verify headers.
+3. Mock `fetch` to test error responses and `OnyxHttpError` handling.
+
+# Plan: Add HttpClient tests with mocks
+1. Create `tests/http-client.spec.ts` covering `parseJsonAllowNaN` and `HttpClient.request` using `vi.fn` mocks.
+2. Simulate both successful and error HTTP responses.
+3. Run `npm run typecheck`, `npm run build`, and `npm test`.
+
+## Acceptance Criteria
+- [x] Tests cover success and error paths of `HttpClient`.
+- [x] `npm test` passes with the new coverage.

--- a/codex/tasks/library-readiness/finished/016-codecov-coverage.md
+++ b/codex/tasks/library-readiness/finished/016-codecov-coverage.md
@@ -1,0 +1,22 @@
+# Task: Add Codecov report and full coverage for core files
+
+## Goal
+Generate an lcov report and reach 100% test coverage for `src/core/http.ts` and `src/errors/config-error.ts`.
+
+## Steps
+1. Add `lcov` reporter in `vitest.config.ts` for Codecov uploads.
+2. Expand tests for `parseJsonAllowNaN` and `HttpClient` to cover constructor branches and error fallback.
+3. Add unit tests for `OnyxConfigError`.
+4. Run `npm run typecheck`, `npm run build`, and `npm test`.
+
+# Plan: Add Codecov report and full coverage for core files
+1. Update `vitest.config.ts` with `lcov` reporter.
+2. Write additional specs in `tests/http-client.spec.ts` for all HttpClient and JSON parsing branches.
+3. Create `tests/config-error.spec.ts` to exercise `OnyxConfigError`.
+4. Verify coverage reaches 100% for `src/core/http.ts` and `src/errors/config-error.ts`.
+5. Execute `npm run typecheck`, `npm run build`, and `npm test`.
+
+## Acceptance Criteria
+- [x] `src/core/http.ts` reports 100% coverage.
+- [x] `src/errors/config-error.ts` reports 100% coverage.
+- [x] Coverage run generates `lcov` output for Codecov.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,113 @@
         "@types/node": "^22.5.0",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
         "@typescript-eslint/parser": "^8.40.0",
+        "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.34.0",
+        "ts-node": "^10.9.2",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -736,6 +836,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1104,6 +1214,34 @@
         "win32"
       ]
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -1380,6 +1518,40 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1518,6 +1690,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1571,6 +1756,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1586,6 +1778,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.4.tgz",
+      "integrity": "sha512-cxrAnZNLBnQwBPByK4CeDaw5sWZtMilJE/Q3iDA0aamgaIVNDF9T6K2/8DfYDZEejZ2jNnDrG9m8MY72HFd0KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.29",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
       }
     },
     "node_modules/balanced-match": {
@@ -1768,6 +1972,13 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1817,6 +2028,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2362,6 +2583,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -2448,6 +2676,60 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -2623,6 +2905,41 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3380,6 +3697,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3548,6 +3880,50 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsup": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
@@ -3661,6 +4037,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.1.3",
@@ -4032,6 +4415,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "npm run build && npm run typecheck"
   },
   "repository": "github:OnyxDevTools/onyx-database",
@@ -39,7 +40,9 @@
     "@types/node": "^22.5.0",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.34.0",
+    "ts-node": "^10.9.2",
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { onyx } from '../src';
+
+describe('basic', () => {
+  it('exports init function', () => {
+    expect(typeof onyx.init).toBe('function');
+  });
+});

--- a/tests/config-error.spec.ts
+++ b/tests/config-error.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { OnyxConfigError } from '../src/errors/config-error';
+
+// filename: tests/config-error.spec.ts
+
+describe('OnyxConfigError', () => {
+  it('sets name and message', () => {
+    const err = new OnyxConfigError('bad');
+    expect(err.name).toBe('OnyxConfigError');
+    expect(err.message).toBe('bad');
+  });
+});

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HttpClient, parseJsonAllowNaN } from '../src/core/http';
+import { OnyxHttpError } from '../src/errors/http-error';
+
+// filename: tests/http-client.spec.ts
+
+describe('parseJsonAllowNaN', () => {
+  it('parses valid JSON normally', () => {
+    const result = parseJsonAllowNaN('{"a":1}') as Record<string, unknown>;
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('replaces NaN and Infinity with null', () => {
+    const result = parseJsonAllowNaN('{"a":NaN,"b":Infinity,"c":-Infinity}') as Record<string, unknown>;
+    expect(result).toEqual({ a: null, b: null, c: null });
+  });
+});
+
+describe('HttpClient', () => {
+  const base = 'https://api.test';
+  const creds = { apiKey: 'k', apiSecret: 's' };
+
+  it('uses provided fetch and returns parsed JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+    const client = new HttpClient({ baseUrl: base, ...creds, fetchImpl: fetchMock });
+    const res = await client.request('POST', '/data', { a: 1 }, { 'X-Custom': 'y' });
+    expect(fetchMock).toHaveBeenCalledWith(`${base}/data`, {
+      method: 'POST',
+      headers: {
+        'x-onyx-key': creds.apiKey,
+        'x-onyx-secret': creds.apiSecret,
+        'Content-Type': 'application/json',
+        'X-Custom': 'y'
+      },
+      body: JSON.stringify({ a: 1 })
+    });
+    expect(res).toEqual({ ok: true });
+  });
+
+  it('passes through string bodies untouched', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => undefined },
+      text: () => Promise.resolve('ok')
+    } as unknown as Response);
+    const client = new HttpClient({ baseUrl: base, ...creds, fetchImpl: fetchMock });
+    await client.request('POST', '/raw', '{"x":1}');
+    expect(fetchMock).toHaveBeenCalledWith(`${base}/raw`, {
+      method: 'POST',
+      headers: {
+        'x-onyx-key': creds.apiKey,
+        'x-onyx-secret': creds.apiSecret,
+        'Content-Type': 'application/json'
+      },
+      body: '{"x":1}'
+    });
+  });
+
+  it('uses global fetch when none provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('pong', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' }
+      })
+    );
+    const original = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock;
+    const client = new HttpClient({ baseUrl: base, ...creds });
+    const res = await client.request('GET', '/ping');
+    expect(fetchMock).toHaveBeenCalled();
+    expect(res).toBe('pong');
+    (globalThis as any).fetch = original;
+  });
+
+  it('throws when no fetch implementation is available', () => {
+    const original = globalThis.fetch;
+    // @ts-ignore
+    delete (globalThis as any).fetch;
+    expect(() => new HttpClient({ baseUrl: base, ...creds })).toThrow(
+      'global fetch is not available; provide OnyxConfig.fetch'
+    );
+    (globalThis as any).fetch = original;
+  });
+
+  it('throws OnyxHttpError on non-ok responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: 'bad' } }), {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+    const client = new HttpClient({ baseUrl: base, ...creds, fetchImpl: fetchMock });
+    await expect(client.request('GET', '/oops')).rejects.toMatchObject({
+      name: 'OnyxHttpError',
+      message: 'bad',
+      status: 401,
+      statusText: 'Unauthorized',
+      body: { error: { message: 'bad' } }
+    });
+  });
+
+  it('falls back to status text when no error message present', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('nope', {
+        status: 500,
+        statusText: 'Server Error',
+        headers: { 'Content-Type': 'text/plain' }
+      })
+    );
+    const client = new HttpClient({ baseUrl: base, ...creds, fetchImpl: fetchMock });
+    await expect(client.request('GET', '/fail')).rejects.toMatchObject({
+      message: '500 Server Error',
+      status: 500,
+      statusText: 'Server Error',
+      body: 'nope'
+    });
+  });
+});
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      include: ['src/**'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- enable lcov reporter for Codecov
- add tests for HttpClient and OnyxConfigError to reach full coverage
- record completed task and changelog entry

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8936f2f083219738573e2bd3b11a