### PR TITLE
docs: add TypeDoc API reference

### DIFF
--- a/changelog/2025-08-23-0901pm-typedoc-docs.md
+++ b/changelog/2025-08-23-0901pm-typedoc-docs.md
@@ -1,0 +1,14 @@
+# Change: add typedoc documentation generation
+
+- Date: 2025-08-23 09:01 PM PT
+- Author/Agent: openai
+- Scope: docs
+- Type: docs
+- Summary:
+  - add TypeDoc config and docs script
+  - generate markdown API reference in docs/
+  - link README to local docs
+- Impact:
+  - documentation only
+- Follow-ups:
+  - none

--- a/codex/tasks/library-readiness/finished/002-typedoc-docs.md
+++ b/codex/tasks/library-readiness/finished/002-typedoc-docs.md
@@ -17,5 +17,5 @@ Auto-generate typed API docs.
 5. Update `README.md` with a link to `./docs`.
 
 ## Acceptance Criteria
-- [ ] `npm run docs` produces `docs/` with generated API reference.
-- [ ] README links to `./docs`.
+- [x] `npm run docs` produces `docs/` with generated API reference.
+- [x] README links to `./docs`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+**@onyx.dev/onyx-database**
+
+***
+
 # @onyx.dev/onyx-database
 
 TypeScript client SDK for **Onyx Cloud Database** — a zero-dependency, strict-typed, builder-pattern API for querying and persisting data in Onyx from Node.js or modern bundlers. Ships ESM & CJS, includes a credential resolver, and an optional **schema code generator** that produces table-safe types and a `tables` enum.

--- a/docs/functions/asc.md
+++ b/docs/functions/asc.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / asc
+
+# Function: asc()
+
+> **asc**(`field`): [`Sort`](../interfaces/Sort.md)
+
+Defined in: helpers/sort.ts:4
+
+## Parameters
+
+### field
+
+`string`
+
+## Returns
+
+[`Sort`](../interfaces/Sort.md)

--- a/docs/functions/avg.md
+++ b/docs/functions/avg.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / avg
+
+# Function: avg()
+
+> **avg**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:2
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/between.md
+++ b/docs/functions/between.md
@@ -1,0 +1,29 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / between
+
+# Function: between()
+
+> **between**(`field`, `lower`, `upper`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:13
+
+## Parameters
+
+### field
+
+`string`
+
+### lower
+
+`unknown`
+
+### upper
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/contains.md
+++ b/docs/functions/contains.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / contains
+
+# Function: contains()
+
+> **contains**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:22
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/containsIgnoreCase.md
+++ b/docs/functions/containsIgnoreCase.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / containsIgnoreCase
+
+# Function: containsIgnoreCase()
+
+> **containsIgnoreCase**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:23
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/count.md
+++ b/docs/functions/count.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / count
+
+# Function: count()
+
+> **count**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:4
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/desc.md
+++ b/docs/functions/desc.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / desc
+
+# Function: desc()
+
+> **desc**(`field`): [`Sort`](../interfaces/Sort.md)
+
+Defined in: helpers/sort.ts:5
+
+## Parameters
+
+### field
+
+`string`
+
+## Returns
+
+[`Sort`](../interfaces/Sort.md)

--- a/docs/functions/eq.md
+++ b/docs/functions/eq.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / eq
+
+# Function: eq()
+
+> **eq**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:9
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/gt.md
+++ b/docs/functions/gt.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / gt
+
+# Function: gt()
+
+> **gt**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:14
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/gte.md
+++ b/docs/functions/gte.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / gte
+
+# Function: gte()
+
+> **gte**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:15
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/inOp.md
+++ b/docs/functions/inOp.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / inOp
+
+# Function: inOp()
+
+> **inOp**(`field`, `values`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:11
+
+## Parameters
+
+### field
+
+`string`
+
+### values
+
+`unknown`[]
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/isNull.md
+++ b/docs/functions/isNull.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / isNull
+
+# Function: isNull()
+
+> **isNull**(`field`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:28
+
+## Parameters
+
+### field
+
+`string`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/like.md
+++ b/docs/functions/like.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / like
+
+# Function: like()
+
+> **like**(`field`, `pattern`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:20
+
+## Parameters
+
+### field
+
+`string`
+
+### pattern
+
+`string`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/lower.md
+++ b/docs/functions/lower.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / lower
+
+# Function: lower()
+
+> **lower**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:11
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/lt.md
+++ b/docs/functions/lt.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / lt
+
+# Function: lt()
+
+> **lt**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:16
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/lte.md
+++ b/docs/functions/lte.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / lte
+
+# Function: lte()
+
+> **lte**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:17
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/matches.md
+++ b/docs/functions/matches.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / matches
+
+# Function: matches()
+
+> **matches**(`field`, `regex`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:18
+
+## Parameters
+
+### field
+
+`string`
+
+### regex
+
+`string`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/max.md
+++ b/docs/functions/max.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / max
+
+# Function: max()
+
+> **max**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:6
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/median.md
+++ b/docs/functions/median.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / median
+
+# Function: median()
+
+> **median**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:9
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/min.md
+++ b/docs/functions/min.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / min
+
+# Function: min()
+
+> **min**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:5
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/neq.md
+++ b/docs/functions/neq.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / neq
+
+# Function: neq()
+
+> **neq**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:10
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/notContains.md
+++ b/docs/functions/notContains.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / notContains
+
+# Function: notContains()
+
+> **notContains**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:24
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/notContainsIgnoreCase.md
+++ b/docs/functions/notContainsIgnoreCase.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / notContainsIgnoreCase
+
+# Function: notContainsIgnoreCase()
+
+> **notContainsIgnoreCase**(`field`, `value`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:25
+
+## Parameters
+
+### field
+
+`string`
+
+### value
+
+`unknown`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/notIn.md
+++ b/docs/functions/notIn.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / notIn
+
+# Function: notIn()
+
+> **notIn**(`field`, `values`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:12
+
+## Parameters
+
+### field
+
+`string`
+
+### values
+
+`unknown`[]
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/notLike.md
+++ b/docs/functions/notLike.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / notLike
+
+# Function: notLike()
+
+> **notLike**(`field`, `pattern`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:21
+
+## Parameters
+
+### field
+
+`string`
+
+### pattern
+
+`string`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/notMatches.md
+++ b/docs/functions/notMatches.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / notMatches
+
+# Function: notMatches()
+
+> **notMatches**(`field`, `regex`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:19
+
+## Parameters
+
+### field
+
+`string`
+
+### regex
+
+`string`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/notNull.md
+++ b/docs/functions/notNull.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / notNull
+
+# Function: notNull()
+
+> **notNull**(`field`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:29
+
+## Parameters
+
+### field
+
+`string`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/notStartsWith.md
+++ b/docs/functions/notStartsWith.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / notStartsWith
+
+# Function: notStartsWith()
+
+> **notStartsWith**(`field`, `prefix`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:27
+
+## Parameters
+
+### field
+
+`string`
+
+### prefix
+
+`string`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/percentile.md
+++ b/docs/functions/percentile.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / percentile
+
+# Function: percentile()
+
+> **percentile**(`attribute`, `p`): `string`
+
+Defined in: helpers/aggregates.ts:16
+
+## Parameters
+
+### attribute
+
+`string`
+
+### p
+
+`number`
+
+## Returns
+
+`string`

--- a/docs/functions/replace.md
+++ b/docs/functions/replace.md
@@ -1,0 +1,29 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / replace
+
+# Function: replace()
+
+> **replace**(`attribute`, `pattern`, `repl`): `string`
+
+Defined in: helpers/aggregates.ts:14
+
+## Parameters
+
+### attribute
+
+`string`
+
+### pattern
+
+`string`
+
+### repl
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/startsWith.md
+++ b/docs/functions/startsWith.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / startsWith
+
+# Function: startsWith()
+
+> **startsWith**(`field`, `prefix`): `ConditionBuilderImpl`
+
+Defined in: helpers/conditions.ts:26
+
+## Parameters
+
+### field
+
+`string`
+
+### prefix
+
+`string`
+
+## Returns
+
+`ConditionBuilderImpl`

--- a/docs/functions/std.md
+++ b/docs/functions/std.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / std
+
+# Function: std()
+
+> **std**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:7
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/substring.md
+++ b/docs/functions/substring.md
@@ -1,0 +1,29 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / substring
+
+# Function: substring()
+
+> **substring**(`attribute`, `from`, `length`): `string`
+
+Defined in: helpers/aggregates.ts:12
+
+## Parameters
+
+### attribute
+
+`string`
+
+### from
+
+`number`
+
+### length
+
+`number`
+
+## Returns
+
+`string`

--- a/docs/functions/sum.md
+++ b/docs/functions/sum.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / sum
+
+# Function: sum()
+
+> **sum**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:3
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/upper.md
+++ b/docs/functions/upper.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / upper
+
+# Function: upper()
+
+> **upper**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:10
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/functions/variance.md
+++ b/docs/functions/variance.md
@@ -1,0 +1,21 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / variance
+
+# Function: variance()
+
+> **variance**(`attribute`): `string`
+
+Defined in: helpers/aggregates.ts:8
+
+## Parameters
+
+### attribute
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -1,0 +1,75 @@
+[**@onyx.dev/onyx-database**](README.md)
+
+***
+
+# @onyx.dev/onyx-database
+
+## Interfaces
+
+- [FetchResponse](interfaces/FetchResponse.md)
+- [ICascadeBuilder](interfaces/ICascadeBuilder.md)
+- [IConditionBuilder](interfaces/IConditionBuilder.md)
+- [IOnyxDatabase](interfaces/IOnyxDatabase.md)
+- [IQueryBuilder](interfaces/IQueryBuilder.md)
+- [ISaveBuilder](interfaces/ISaveBuilder.md)
+- [OnyxConfig](interfaces/OnyxConfig.md)
+- [OnyxDocument](interfaces/OnyxDocument.md)
+- [OnyxFacade](interfaces/OnyxFacade.md)
+- [QueryCriteria](interfaces/QueryCriteria.md)
+- [QueryPage](interfaces/QueryPage.md)
+- [SelectQuery](interfaces/SelectQuery.md)
+- [Sort](interfaces/Sort.md)
+- [UpdateQuery](interfaces/UpdateQuery.md)
+
+## Type Aliases
+
+- [FetchImpl](type-aliases/FetchImpl.md)
+- [LogicalOperator](type-aliases/LogicalOperator.md)
+- [QueryCondition](type-aliases/QueryCondition.md)
+- [QueryCriteriaOperator](type-aliases/QueryCriteriaOperator.md)
+- [StreamAction](type-aliases/StreamAction.md)
+
+## Variables
+
+- [onyx](variables/onyx.md)
+- [sdkName](variables/sdkName.md)
+- [sdkVersion](variables/sdkVersion.md)
+
+## Functions
+
+- [asc](functions/asc.md)
+- [avg](functions/avg.md)
+- [between](functions/between.md)
+- [contains](functions/contains.md)
+- [containsIgnoreCase](functions/containsIgnoreCase.md)
+- [count](functions/count.md)
+- [desc](functions/desc.md)
+- [eq](functions/eq.md)
+- [gt](functions/gt.md)
+- [gte](functions/gte.md)
+- [inOp](functions/inOp.md)
+- [isNull](functions/isNull.md)
+- [like](functions/like.md)
+- [lower](functions/lower.md)
+- [lt](functions/lt.md)
+- [lte](functions/lte.md)
+- [matches](functions/matches.md)
+- [max](functions/max.md)
+- [median](functions/median.md)
+- [min](functions/min.md)
+- [neq](functions/neq.md)
+- [notContains](functions/notContains.md)
+- [notContainsIgnoreCase](functions/notContainsIgnoreCase.md)
+- [notIn](functions/notIn.md)
+- [notLike](functions/notLike.md)
+- [notMatches](functions/notMatches.md)
+- [notNull](functions/notNull.md)
+- [notStartsWith](functions/notStartsWith.md)
+- [percentile](functions/percentile.md)
+- [replace](functions/replace.md)
+- [startsWith](functions/startsWith.md)
+- [std](functions/std.md)
+- [substring](functions/substring.md)
+- [sum](functions/sum.md)
+- [upper](functions/upper.md)
+- [variance](functions/variance.md)

--- a/docs/interfaces/FetchResponse.md
+++ b/docs/interfaces/FetchResponse.md
@@ -1,0 +1,79 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / FetchResponse
+
+# Interface: FetchResponse
+
+Defined in: types/common.ts:30
+
+Minimal fetch typing to avoid DOM lib dependency
+
+## Properties
+
+### body?
+
+> `optional` **body**: `unknown`
+
+Defined in: types/common.ts:37
+
+raw body for streams; left as unknown to avoid DOM typings
+
+***
+
+### headers
+
+> **headers**: `object`
+
+Defined in: types/common.ts:34
+
+#### get()
+
+> **get**(`name`): `null` \| `string`
+
+##### Parameters
+
+###### name
+
+`string`
+
+##### Returns
+
+`null` \| `string`
+
+***
+
+### ok
+
+> **ok**: `boolean`
+
+Defined in: types/common.ts:31
+
+***
+
+### status
+
+> **status**: `number`
+
+Defined in: types/common.ts:32
+
+***
+
+### statusText
+
+> **statusText**: `string`
+
+Defined in: types/common.ts:33
+
+## Methods
+
+### text()
+
+> **text**(): `Promise`\<`string`\>
+
+Defined in: types/common.ts:35
+
+#### Returns
+
+`Promise`\<`string`\>

--- a/docs/interfaces/ICascadeBuilder.md
+++ b/docs/interfaces/ICascadeBuilder.md
@@ -1,0 +1,83 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / ICascadeBuilder
+
+# Interface: ICascadeBuilder\<Schema\>
+
+Defined in: types/builders.ts:48
+
+## Type Parameters
+
+### Schema
+
+`Schema` = `Record`\<`string`, `unknown`\>
+
+## Methods
+
+### cascade()
+
+> **cascade**(...`relationships`): `ICascadeBuilder`\<`Schema`\>
+
+Defined in: types/builders.ts:49
+
+#### Parameters
+
+##### relationships
+
+...`string`[]
+
+#### Returns
+
+`ICascadeBuilder`\<`Schema`\>
+
+***
+
+### delete()
+
+> **delete**(`table`, `primaryKey`): `Promise`\<`unknown`\>
+
+Defined in: types/builders.ts:54
+
+#### Parameters
+
+##### table
+
+`string`
+
+##### primaryKey
+
+`string`
+
+#### Returns
+
+`Promise`\<`unknown`\>
+
+***
+
+### save()
+
+> **save**\<`Table`\>(`table`, `entityOrEntities`): `Promise`\<`unknown`\>
+
+Defined in: types/builders.ts:50
+
+#### Type Parameters
+
+##### Table
+
+`Table` *extends* `string`
+
+#### Parameters
+
+##### table
+
+`Table`
+
+##### entityOrEntities
+
+`Partial`\<`Schema`\[`Table`\]\> | `Partial`\<`Schema`\[`Table`\]\>[]
+
+#### Returns
+
+`Promise`\<`unknown`\>

--- a/docs/interfaces/IConditionBuilder.md
+++ b/docs/interfaces/IConditionBuilder.md
@@ -1,0 +1,57 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / IConditionBuilder
+
+# Interface: IConditionBuilder
+
+Defined in: types/builders.ts:5
+
+## Methods
+
+### and()
+
+> **and**(`condition`): `IConditionBuilder`
+
+Defined in: types/builders.ts:6
+
+#### Parameters
+
+##### condition
+
+[`QueryCriteria`](QueryCriteria.md) | `IConditionBuilder`
+
+#### Returns
+
+`IConditionBuilder`
+
+***
+
+### or()
+
+> **or**(`condition`): `IConditionBuilder`
+
+Defined in: types/builders.ts:7
+
+#### Parameters
+
+##### condition
+
+[`QueryCriteria`](QueryCriteria.md) | `IConditionBuilder`
+
+#### Returns
+
+`IConditionBuilder`
+
+***
+
+### toCondition()
+
+> **toCondition**(): [`QueryCondition`](../type-aliases/QueryCondition.md)
+
+Defined in: types/builders.ts:8
+
+#### Returns
+
+[`QueryCondition`](../type-aliases/QueryCondition.md)

--- a/docs/interfaces/IOnyxDatabase.md
+++ b/docs/interfaces/IOnyxDatabase.md
@@ -1,0 +1,285 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / IOnyxDatabase
+
+# Interface: IOnyxDatabase\<Schema\>
+
+Defined in: types/public.ts:13
+
+## Type Parameters
+
+### Schema
+
+`Schema` = `Record`\<`string`, `unknown`\>
+
+## Methods
+
+### cascade()
+
+> **cascade**(...`relationships`): [`ICascadeBuilder`](ICascadeBuilder.md)\<`Schema`\>
+
+Defined in: types/public.ts:16
+
+#### Parameters
+
+##### relationships
+
+...`string`[]
+
+#### Returns
+
+[`ICascadeBuilder`](ICascadeBuilder.md)\<`Schema`\>
+
+***
+
+### close()
+
+> **close**(): `void`
+
+Defined in: types/public.ts:42
+
+Cancels active streams; safe to call multiple times
+
+#### Returns
+
+`void`
+
+***
+
+### delete()
+
+> **delete**(`table`, `primaryKey`, `options?`): `Promise`\<`unknown`\>
+
+Defined in: types/public.ts:31
+
+#### Parameters
+
+##### table
+
+`string`
+
+##### primaryKey
+
+`string`
+
+##### options?
+
+###### partition?
+
+`string`
+
+###### relationships?
+
+`string`[]
+
+#### Returns
+
+`Promise`\<`unknown`\>
+
+***
+
+### deleteDocument()
+
+> **deleteDocument**(`documentId`): `Promise`\<`unknown`\>
+
+Defined in: types/public.ts:39
+
+#### Parameters
+
+##### documentId
+
+`string`
+
+#### Returns
+
+`Promise`\<`unknown`\>
+
+***
+
+### findById()
+
+> **findById**\<`Table`, `T`\>(`table`, `primaryKey`, `options?`): `Promise`\<`T`\>
+
+Defined in: types/public.ts:25
+
+#### Type Parameters
+
+##### Table
+
+`Table` *extends* `string`
+
+##### T
+
+`T` = `Schema`\[`Table`\]
+
+#### Parameters
+
+##### table
+
+`Table`
+
+##### primaryKey
+
+`string`
+
+##### options?
+
+###### partition?
+
+`string`
+
+###### resolvers?
+
+`string`[]
+
+#### Returns
+
+`Promise`\<`T`\>
+
+***
+
+### from()
+
+> **from**\<`Table`\>(`table`): [`IQueryBuilder`](IQueryBuilder.md)\<`Schema`\[`Table`\]\>
+
+Defined in: types/public.ts:14
+
+#### Type Parameters
+
+##### Table
+
+`Table` *extends* `string`
+
+#### Parameters
+
+##### table
+
+`Table`
+
+#### Returns
+
+[`IQueryBuilder`](IQueryBuilder.md)\<`Schema`\[`Table`\]\>
+
+***
+
+### getDocument()
+
+> **getDocument**(`documentId`, `options?`): `Promise`\<`unknown`\>
+
+Defined in: types/public.ts:38
+
+#### Parameters
+
+##### documentId
+
+`string`
+
+##### options?
+
+###### height?
+
+`number`
+
+###### width?
+
+`number`
+
+#### Returns
+
+`Promise`\<`unknown`\>
+
+***
+
+### save()
+
+#### Call Signature
+
+> **save**\<`Table`\>(`table`): [`ISaveBuilder`](ISaveBuilder.md)\<`Schema`\[`Table`\]\>
+
+Defined in: types/public.ts:18
+
+##### Type Parameters
+
+###### Table
+
+`Table` *extends* `string`
+
+##### Parameters
+
+###### table
+
+`Table`
+
+##### Returns
+
+[`ISaveBuilder`](ISaveBuilder.md)\<`Schema`\[`Table`\]\>
+
+#### Call Signature
+
+> **save**\<`Table`\>(`table`, `entityOrEntities`, `options?`): `Promise`\<`unknown`\>
+
+Defined in: types/public.ts:19
+
+##### Type Parameters
+
+###### Table
+
+`Table` *extends* `string`
+
+##### Parameters
+
+###### table
+
+`Table`
+
+###### entityOrEntities
+
+`Partial`\<`Schema`\[`Table`\]\> | `Partial`\<`Schema`\[`Table`\]\>[]
+
+###### options?
+
+###### relationships?
+
+`string`[]
+
+##### Returns
+
+`Promise`\<`unknown`\>
+
+***
+
+### saveDocument()
+
+> **saveDocument**(`doc`): `Promise`\<`unknown`\>
+
+Defined in: types/public.ts:37
+
+#### Parameters
+
+##### doc
+
+[`OnyxDocument`](OnyxDocument.md)
+
+#### Returns
+
+`Promise`\<`unknown`\>
+
+***
+
+### select()
+
+> **select**(...`fields`): [`IQueryBuilder`](IQueryBuilder.md)\<`Record`\<`string`, `unknown`\>\>
+
+Defined in: types/public.ts:15
+
+#### Parameters
+
+##### fields
+
+...`string`[]
+
+#### Returns
+
+[`IQueryBuilder`](IQueryBuilder.md)\<`Record`\<`string`, `unknown`\>\>

--- a/docs/interfaces/IQueryBuilder.md
+++ b/docs/interfaces/IQueryBuilder.md
@@ -1,0 +1,439 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / IQueryBuilder
+
+# Interface: IQueryBuilder\<T\>
+
+Defined in: types/builders.ts:11
+
+## Type Parameters
+
+### T
+
+`T` = `unknown`
+
+## Methods
+
+### and()
+
+> **and**(`condition`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:16
+
+#### Parameters
+
+##### condition
+
+[`QueryCriteria`](QueryCriteria.md) | [`IConditionBuilder`](IConditionBuilder.md)
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### count()
+
+> **count**(): `Promise`\<`number`\>
+
+Defined in: types/builders.ts:27
+
+#### Returns
+
+`Promise`\<`number`\>
+
+***
+
+### delete()
+
+> **delete**(): `Promise`\<`unknown`\>
+
+Defined in: types/builders.ts:33
+
+#### Returns
+
+`Promise`\<`unknown`\>
+
+***
+
+### distinct()
+
+> **distinct**(): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:20
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### from()
+
+> **from**(`table`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:12
+
+#### Parameters
+
+##### table
+
+`string`
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### groupBy()
+
+> **groupBy**(...`fields`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:19
+
+#### Parameters
+
+##### fields
+
+...`string`[]
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### inPartition()
+
+> **inPartition**(`partition`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:22
+
+#### Parameters
+
+##### partition
+
+`string`
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### limit()
+
+> **limit**(`n`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:21
+
+#### Parameters
+
+##### n
+
+`number`
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### list()
+
+> **list**(`options?`): `Promise`\<`T`[]\>
+
+Defined in: types/builders.ts:28
+
+#### Parameters
+
+##### options?
+
+###### nextPage?
+
+`string`
+
+###### pageSize?
+
+`number`
+
+#### Returns
+
+`Promise`\<`T`[]\>
+
+***
+
+### nextPage()
+
+> **nextPage**(`token`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:25
+
+#### Parameters
+
+##### token
+
+`string`
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### onItem()
+
+> **onItem**(`listener`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:38
+
+#### Parameters
+
+##### listener
+
+(`entity`, `action`) => `void`
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### onItemAdded()
+
+> **onItemAdded**(`listener`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:35
+
+#### Parameters
+
+##### listener
+
+(`entity`) => `void`
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### onItemDeleted()
+
+> **onItemDeleted**(`listener`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:37
+
+#### Parameters
+
+##### listener
+
+(`entity`) => `void`
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### onItemUpdated()
+
+> **onItemUpdated**(`listener`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:36
+
+#### Parameters
+
+##### listener
+
+(`entity`) => `void`
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### or()
+
+> **or**(`condition`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:17
+
+#### Parameters
+
+##### condition
+
+[`QueryCriteria`](QueryCriteria.md) | [`IConditionBuilder`](IConditionBuilder.md)
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### orderBy()
+
+> **orderBy**(...`sorts`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:18
+
+#### Parameters
+
+##### sorts
+
+...[`Sort`](Sort.md)[]
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### page()
+
+> **page**(`options?`): `Promise`\<\{ `nextPage?`: `null` \| `string`; `records`: `T`[]; \}\>
+
+Defined in: types/builders.ts:29
+
+#### Parameters
+
+##### options?
+
+###### nextPage?
+
+`string`
+
+###### pageSize?
+
+`number`
+
+#### Returns
+
+`Promise`\<\{ `nextPage?`: `null` \| `string`; `records`: `T`[]; \}\>
+
+***
+
+### pageSize()
+
+> **pageSize**(`n`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:24
+
+#### Parameters
+
+##### n
+
+`number`
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### resolve()
+
+> **resolve**(`values`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:14
+
+#### Parameters
+
+##### values
+
+`string` | `string`[]
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### selectFields()
+
+> **selectFields**(`fields`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:13
+
+#### Parameters
+
+##### fields
+
+`string`[]
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### setUpdates()
+
+> **setUpdates**(`updates`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:31
+
+#### Parameters
+
+##### updates
+
+`Partial`\<`T`\>
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>
+
+***
+
+### stream()
+
+> **stream**(`includeQueryResults?`, `keepAlive?`): `Promise`\<\{ `cancel`: () => `void`; \}\>
+
+Defined in: types/builders.ts:39
+
+#### Parameters
+
+##### includeQueryResults?
+
+`boolean`
+
+##### keepAlive?
+
+`boolean`
+
+#### Returns
+
+`Promise`\<\{ `cancel`: () => `void`; \}\>
+
+***
+
+### update()
+
+> **update**(): `Promise`\<`unknown`\>
+
+Defined in: types/builders.ts:32
+
+#### Returns
+
+`Promise`\<`unknown`\>
+
+***
+
+### where()
+
+> **where**(`condition`): `IQueryBuilder`\<`T`\>
+
+Defined in: types/builders.ts:15
+
+#### Parameters
+
+##### condition
+
+[`QueryCriteria`](QueryCriteria.md) | [`IConditionBuilder`](IConditionBuilder.md)
+
+#### Returns
+
+`IQueryBuilder`\<`T`\>

--- a/docs/interfaces/ISaveBuilder.md
+++ b/docs/interfaces/ISaveBuilder.md
@@ -1,0 +1,69 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / ISaveBuilder
+
+# Interface: ISaveBuilder\<T\>
+
+Defined in: types/builders.ts:42
+
+## Type Parameters
+
+### T
+
+`T` = `unknown`
+
+## Methods
+
+### cascade()
+
+> **cascade**(...`relationships`): `ISaveBuilder`\<`T`\>
+
+Defined in: types/builders.ts:43
+
+#### Parameters
+
+##### relationships
+
+...`string`[]
+
+#### Returns
+
+`ISaveBuilder`\<`T`\>
+
+***
+
+### many()
+
+> **many**(`entities`): `Promise`\<`unknown`\>
+
+Defined in: types/builders.ts:45
+
+#### Parameters
+
+##### entities
+
+`Partial`\<`T`\>[]
+
+#### Returns
+
+`Promise`\<`unknown`\>
+
+***
+
+### one()
+
+> **one**(`entity`): `Promise`\<`unknown`\>
+
+Defined in: types/builders.ts:44
+
+#### Parameters
+
+##### entity
+
+`Partial`\<`T`\>
+
+#### Returns
+
+`Promise`\<`unknown`\>

--- a/docs/interfaces/OnyxConfig.md
+++ b/docs/interfaces/OnyxConfig.md
@@ -1,0 +1,49 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / OnyxConfig
+
+# Interface: OnyxConfig
+
+Defined in: types/public.ts:5
+
+## Properties
+
+### apiKey?
+
+> `optional` **apiKey**: `string`
+
+Defined in: types/public.ts:8
+
+***
+
+### apiSecret?
+
+> `optional` **apiSecret**: `string`
+
+Defined in: types/public.ts:9
+
+***
+
+### baseUrl?
+
+> `optional` **baseUrl**: `string`
+
+Defined in: types/public.ts:6
+
+***
+
+### databaseId?
+
+> `optional` **databaseId**: `string`
+
+Defined in: types/public.ts:7
+
+***
+
+### fetch?
+
+> `optional` **fetch**: [`FetchImpl`](../type-aliases/FetchImpl.md)
+
+Defined in: types/public.ts:10

--- a/docs/interfaces/OnyxDocument.md
+++ b/docs/interfaces/OnyxDocument.md
@@ -1,0 +1,57 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / OnyxDocument
+
+# Interface: OnyxDocument
+
+Defined in: types/common.ts:20
+
+## Properties
+
+### content?
+
+> `optional` **content**: `string`
+
+Defined in: types/common.ts:26
+
+***
+
+### created?
+
+> `optional` **created**: `Date`
+
+Defined in: types/common.ts:23
+
+***
+
+### documentId?
+
+> `optional` **documentId**: `string`
+
+Defined in: types/common.ts:21
+
+***
+
+### mimeType?
+
+> `optional` **mimeType**: `string`
+
+Defined in: types/common.ts:25
+
+***
+
+### path?
+
+> `optional` **path**: `string`
+
+Defined in: types/common.ts:22
+
+***
+
+### updated?
+
+> `optional` **updated**: `Date`
+
+Defined in: types/common.ts:24

--- a/docs/interfaces/OnyxFacade.md
+++ b/docs/interfaces/OnyxFacade.md
@@ -1,0 +1,33 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / OnyxFacade
+
+# Interface: OnyxFacade
+
+Defined in: types/public.ts:45
+
+## Methods
+
+### init()
+
+> **init**\<`Schema`\>(`config?`): [`IOnyxDatabase`](IOnyxDatabase.md)\<`Schema`\>
+
+Defined in: types/public.ts:46
+
+#### Type Parameters
+
+##### Schema
+
+`Schema` = `Record`\<`string`, `unknown`\>
+
+#### Parameters
+
+##### config?
+
+[`OnyxConfig`](OnyxConfig.md)
+
+#### Returns
+
+[`IOnyxDatabase`](IOnyxDatabase.md)\<`Schema`\>

--- a/docs/interfaces/QueryCriteria.md
+++ b/docs/interfaces/QueryCriteria.md
@@ -1,0 +1,33 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / QueryCriteria
+
+# Interface: QueryCriteria
+
+Defined in: types/protocol.ts:4
+
+## Properties
+
+### field
+
+> **field**: `string`
+
+Defined in: types/protocol.ts:5
+
+***
+
+### operator
+
+> **operator**: [`QueryCriteriaOperator`](../type-aliases/QueryCriteriaOperator.md)
+
+Defined in: types/protocol.ts:6
+
+***
+
+### value?
+
+> `optional` **value**: `unknown`
+
+Defined in: types/protocol.ts:7

--- a/docs/interfaces/QueryPage.md
+++ b/docs/interfaces/QueryPage.md
@@ -1,0 +1,31 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / QueryPage
+
+# Interface: QueryPage\<T\>
+
+Defined in: types/protocol.ts:35
+
+## Type Parameters
+
+### T
+
+`T`
+
+## Properties
+
+### nextPage?
+
+> `optional` **nextPage**: `null` \| `string`
+
+Defined in: types/protocol.ts:37
+
+***
+
+### records
+
+> **records**: `T`[]
+
+Defined in: types/protocol.ts:36

--- a/docs/interfaces/SelectQuery.md
+++ b/docs/interfaces/SelectQuery.md
@@ -1,0 +1,81 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / SelectQuery
+
+# Interface: SelectQuery
+
+Defined in: types/protocol.ts:14
+
+## Properties
+
+### conditions?
+
+> `optional` **conditions**: `null` \| [`QueryCondition`](../type-aliases/QueryCondition.md)
+
+Defined in: types/protocol.ts:17
+
+***
+
+### distinct?
+
+> `optional` **distinct**: `null` \| `boolean`
+
+Defined in: types/protocol.ts:20
+
+***
+
+### fields?
+
+> `optional` **fields**: `null` \| `string`[]
+
+Defined in: types/protocol.ts:16
+
+***
+
+### groupBy?
+
+> `optional` **groupBy**: `null` \| `string`[]
+
+Defined in: types/protocol.ts:21
+
+***
+
+### limit?
+
+> `optional` **limit**: `null` \| `number`
+
+Defined in: types/protocol.ts:19
+
+***
+
+### partition?
+
+> `optional` **partition**: `null` \| `string`
+
+Defined in: types/protocol.ts:22
+
+***
+
+### resolvers?
+
+> `optional` **resolvers**: `null` \| `string`[]
+
+Defined in: types/protocol.ts:23
+
+***
+
+### sort?
+
+> `optional` **sort**: `null` \| [`Sort`](Sort.md)[]
+
+Defined in: types/protocol.ts:18
+
+***
+
+### type
+
+> **type**: `"SelectQuery"`
+
+Defined in: types/protocol.ts:15

--- a/docs/interfaces/Sort.md
+++ b/docs/interfaces/Sort.md
@@ -1,0 +1,25 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / Sort
+
+# Interface: Sort
+
+Defined in: types/common.ts:16
+
+## Properties
+
+### field
+
+> **field**: `string`
+
+Defined in: types/common.ts:16
+
+***
+
+### order
+
+> **order**: `"ASC"` \| `"DESC"`
+
+Defined in: types/common.ts:16

--- a/docs/interfaces/UpdateQuery.md
+++ b/docs/interfaces/UpdateQuery.md
@@ -1,0 +1,57 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / UpdateQuery
+
+# Interface: UpdateQuery
+
+Defined in: types/protocol.ts:26
+
+## Properties
+
+### conditions?
+
+> `optional` **conditions**: `null` \| [`QueryCondition`](../type-aliases/QueryCondition.md)
+
+Defined in: types/protocol.ts:28
+
+***
+
+### limit?
+
+> `optional` **limit**: `null` \| `number`
+
+Defined in: types/protocol.ts:31
+
+***
+
+### partition?
+
+> `optional` **partition**: `null` \| `string`
+
+Defined in: types/protocol.ts:32
+
+***
+
+### sort?
+
+> `optional` **sort**: `null` \| [`Sort`](Sort.md)[]
+
+Defined in: types/protocol.ts:30
+
+***
+
+### type
+
+> **type**: `"UpdateQuery"`
+
+Defined in: types/protocol.ts:27
+
+***
+
+### updates
+
+> **updates**: `Record`\<`string`, `unknown`\>
+
+Defined in: types/protocol.ts:29

--- a/docs/type-aliases/FetchImpl.md
+++ b/docs/type-aliases/FetchImpl.md
@@ -1,0 +1,35 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / FetchImpl
+
+# Type Alias: FetchImpl()
+
+> **FetchImpl** = (`url`, `init?`) => `Promise`\<[`FetchResponse`](../interfaces/FetchResponse.md)\>
+
+Defined in: types/common.ts:39
+
+## Parameters
+
+### url
+
+`string`
+
+### init?
+
+#### body?
+
+`string`
+
+#### headers?
+
+`Record`\<`string`, `string`\>
+
+#### method?
+
+`string`
+
+## Returns
+
+`Promise`\<[`FetchResponse`](../interfaces/FetchResponse.md)\>

--- a/docs/type-aliases/LogicalOperator.md
+++ b/docs/type-aliases/LogicalOperator.md
@@ -1,0 +1,11 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / LogicalOperator
+
+# Type Alias: LogicalOperator
+
+> **LogicalOperator** = `"AND"` \| `"OR"`
+
+Defined in: types/common.ts:14

--- a/docs/type-aliases/QueryCondition.md
+++ b/docs/type-aliases/QueryCondition.md
@@ -1,0 +1,11 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / QueryCondition
+
+# Type Alias: QueryCondition
+
+> **QueryCondition** = \{ `conditionType`: `"SingleCondition"`; `criteria`: [`QueryCriteria`](../interfaces/QueryCriteria.md); \} \| \{ `conditions`: `QueryCondition`[]; `conditionType`: `"CompoundCondition"`; `operator`: [`LogicalOperator`](LogicalOperator.md); \}
+
+Defined in: types/protocol.ts:10

--- a/docs/type-aliases/QueryCriteriaOperator.md
+++ b/docs/type-aliases/QueryCriteriaOperator.md
@@ -1,0 +1,11 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / QueryCriteriaOperator
+
+# Type Alias: QueryCriteriaOperator
+
+> **QueryCriteriaOperator** = `"EQUAL"` \| `"NOT_EQUAL"` \| `"IN"` \| `"NOT_IN"` \| `"GREATER_THAN"` \| `"GREATER_THAN_EQUAL"` \| `"LESS_THAN"` \| `"LESS_THAN_EQUAL"` \| `"MATCHES"` \| `"NOT_MATCHES"` \| `"BETWEEN"` \| `"LIKE"` \| `"NOT_LIKE"` \| `"CONTAINS"` \| `"CONTAINS_IGNORE_CASE"` \| `"NOT_CONTAINS"` \| `"NOT_CONTAINS_IGNORE_CASE"` \| `"STARTS_WITH"` \| `"NOT_STARTS_WITH"` \| `"IS_NULL"` \| `"NOT_NULL"`
+
+Defined in: types/common.ts:2

--- a/docs/type-aliases/StreamAction.md
+++ b/docs/type-aliases/StreamAction.md
@@ -1,0 +1,11 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / StreamAction
+
+# Type Alias: StreamAction
+
+> **StreamAction** = `"CREATE"` \| `"UPDATE"` \| `"DELETE"` \| `"QUERY_RESPONSE"` \| `"KEEP_ALIVE"`
+
+Defined in: types/common.ts:18

--- a/docs/variables/onyx.md
+++ b/docs/variables/onyx.md
@@ -1,0 +1,15 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / onyx
+
+# Variable: onyx
+
+> `const` **onyx**: [`OnyxFacade`](../interfaces/OnyxFacade.md)
+
+Defined in: impl/onyx.ts:601
+
+-------------------------
+Facade export
+--------------------------

--- a/docs/variables/sdkName.md
+++ b/docs/variables/sdkName.md
@@ -1,0 +1,11 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / sdkName
+
+# Variable: sdkName
+
+> `const` **sdkName**: `"@onyx.dev/onyx-database"` = `'@onyx.dev/onyx-database'`
+
+Defined in: index.ts:2

--- a/docs/variables/sdkVersion.md
+++ b/docs/variables/sdkVersion.md
@@ -1,0 +1,11 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / sdkVersion
+
+# Variable: sdkVersion
+
+> `const` **sdkVersion**: `"0.1.0"` = `'0.1.0'`
+
+Defined in: index.ts:3

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "eslint": "^9.34.0",
         "ts-node": "^10.9.2",
         "tsup": "^8.5.0",
+        "typedoc": "^0.28.10",
+        "typedoc-plugin-markdown": "^4.8.1",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
       },
@@ -752,6 +754,20 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.11.0.tgz",
+      "integrity": "sha512-ooCDMAOKv71O7MszbXjSQGcI6K5T6NKlemQZOBHLq7Sv/oXCRfYbZ7UgbzFdl20lSXju6Juds4I3y30R6rHA4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.11.0",
+        "@shikijs/langs": "^3.11.0",
+        "@shikijs/themes": "^3.11.0",
+        "@shikijs/types": "^3.11.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1214,6 +1230,55 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.11.0.tgz",
+      "integrity": "sha512-4DwIjIgETK04VneKbfOE4WNm4Q7WC1wo95wv82PoHKdqX4/9qLRUwrfKlmhf0gAuvT6GHy0uc7t9cailk6Tbhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.11.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.11.0.tgz",
+      "integrity": "sha512-Njg/nFL4HDcf/ObxcK2VeyidIq61EeLmocrwTHGGpOQx0BzrPWM1j55XtKQ1LvvDWH15cjQy7rg96aJ1/l63uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.11.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.11.0.tgz",
+      "integrity": "sha512-BhhWRzCTEk2CtWt4S4bgsOqPJRkapvxdsifAwqP+6mk5uxboAQchc0etiJ0iIasxnMsb764qGD24DK9albcU9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.11.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.11.0.tgz",
+      "integrity": "sha512-RB7IMo2E7NZHyfkqAuaf4CofyY8bPzjWPjJRzn6SEak3b46fIQyG6Vx5fG/obqkfppQ+g8vEsiD7Uc6lqQt32Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1266,6 +1331,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1282,6 +1357,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.40.0",
@@ -2052,6 +2134,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2842,6 +2937,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -2896,6 +3001,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.18",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
@@ -2940,6 +3052,31 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3311,6 +3448,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4000,6 +4147,43 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.10.tgz",
+      "integrity": "sha512-zYvpjS2bNJ30SoNYfHSRaFpBMZAsL7uwKbWwqoCNFWjcPnI3e/mPLh2SneH9mX7SJxtDpvDgvd9/iZxGbo7daw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.9.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.8.0"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.8.1.tgz",
+      "integrity": "sha512-ug7fc4j0SiJxSwBGLncpSo8tLvrT9VONvPUQqQDTKPxCoFQBADLli832RGPtj6sfSVJebNSrHZQRUdEryYH/7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typedoc": "0.28.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -4013,6 +4197,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.1",
@@ -4415,6 +4606,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prepublishOnly": "npm run build && npm run typecheck"
+    "prepublishOnly": "npm run build && npm run typecheck",
+    "docs": "typedoc"
   },
   "repository": "github:OnyxDevTools/onyx-database",
   "publishConfig": {
@@ -44,6 +45,8 @@
     "eslint": "^9.34.0",
     "ts-node": "^10.9.2",
     "tsup": "^8.5.0",
+    "typedoc": "^0.28.10",
+    "typedoc-plugin-markdown": "^4.8.1",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "plugin": ["typedoc-plugin-markdown"]
+}


### PR DESCRIPTION
## Summary
- generate markdown API reference with TypeDoc
- link README to newly generated docs
- record task completion in codex and changelog

## Testing
- `npm run docs`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8e5c21b48321adcf0fe82512acfa