### PR TITLE
test: add comprehensive builder coverage

### DIFF
--- a/changelog/2025-08-23-0907pm-builders-test-coverage.md
+++ b/changelog/2025-08-23-0907pm-builders-test-coverage.md
@@ -1,0 +1,13 @@
+# Change: add tests for builders
+
+- Date: 2025-08-23 09:07 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: test
+- Summary:
+  - add unit tests for CascadeBuilder, SaveBuilder, ConditionBuilder, and QueryBuilder
+  - reach 100% coverage for `src/builders`
+- Impact:
+  - improves confidence in builder APIs
+- Follow-ups:
+  - none

--- a/codex/tasks/library-readiness/finished/017-builders-test-coverage.md
+++ b/codex/tasks/library-readiness/finished/017-builders-test-coverage.md
@@ -1,0 +1,17 @@
+# Task: Ensure 100% test coverage for builders
+
+## Goal
+Cover all builder implementations under `src/builders` with exhaustive unit tests.
+
+## Steps
+1. Add tests for `CascadeBuilder` covering save and delete with and without `cascade` relationships.
+2. Add tests for `SaveBuilder` handling `one` and `many` saves and relationship options.
+3. Add tests for `ConditionBuilderImpl` including `and`, `or`, compound logic, `toCondition` error, and invalid input.
+4. Add tests for `QueryBuilder` to exercise query construction, AND/OR combinations, list/page/update/delete/count/stream flows, and misuse errors.
+5. Run `npm run typecheck`, `npm run build`, and `npm test -- --coverage`.
+
+## Acceptance Criteria
+- [x] Tests achieve 100% coverage for files in `src/builders`.
+- [x] `npm run typecheck` passes.
+- [x] `npm run build` passes.
+- [x] `npm test -- --coverage` passes.

--- a/tests/cascade-builder.spec.ts
+++ b/tests/cascade-builder.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CascadeBuilder } from '../src/builders/cascade-builder';
+
+describe('CascadeBuilder', () => {
+  it('saves with and without relationships', async () => {
+    const save = vi.fn().mockResolvedValue('ok');
+    const db = { save } as any;
+    const builder = new CascadeBuilder(db);
+
+    await builder.save('Users', { id: 1 });
+    expect(save).toHaveBeenCalledWith('Users', { id: 1 }, undefined);
+
+    builder.cascade('relA', 'relB');
+    await builder.save('Users', [{ id: 2 }]);
+    expect(save).toHaveBeenLastCalledWith('Users', [{ id: 2 }], { relationships: ['relA', 'relB'] });
+  });
+
+  it('deletes with and without relationships', async () => {
+    const del = vi.fn().mockResolvedValue('ok');
+    const db = { delete: del } as any;
+    const builder = new CascadeBuilder(db);
+
+    await builder.delete('Users', '1');
+    expect(del).toHaveBeenCalledWith('Users', '1', undefined);
+
+    builder.cascade('rel');
+    await builder.delete('Users', '2');
+    expect(del).toHaveBeenLastCalledWith('Users', '2', { relationships: ['rel'] });
+  });
+});

--- a/tests/condition-builder.spec.ts
+++ b/tests/condition-builder.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { ConditionBuilderImpl } from '../src/builders/condition-builder';
+
+describe('ConditionBuilderImpl', () => {
+  it('builds compound conditions with and/or', () => {
+    const cb = new ConditionBuilderImpl();
+    const other = new ConditionBuilderImpl({ field: 'b', operator: '=', value: 2 });
+
+    cb.and({ field: 'a', operator: '=', value: 1 })
+      .and(other)
+      .and({ field: 'd', operator: '=', value: 4 })
+      .or({ field: 'c', operator: '=', value: 3 });
+
+    expect(cb.toCondition()).toEqual({
+      conditionType: 'CompoundCondition',
+      operator: 'OR',
+      conditions: [
+        {
+          conditionType: 'CompoundCondition',
+          operator: 'AND',
+          conditions: [
+            { conditionType: 'SingleCondition', criteria: { field: 'a', operator: '=', value: 1 } },
+            { conditionType: 'SingleCondition', criteria: { field: 'b', operator: '=', value: 2 } },
+            { conditionType: 'SingleCondition', criteria: { field: 'd', operator: '=', value: 4 } }
+          ]
+        },
+        { conditionType: 'SingleCondition', criteria: { field: 'c', operator: '=', value: 3 } }
+      ]
+    });
+  });
+
+  it('throws when no criteria or invalid input', () => {
+    const empty = new ConditionBuilderImpl();
+    expect(() => empty.toCondition()).toThrow('ConditionBuilder has no criteria.');
+    expect(() => empty.and({} as any)).toThrow('Invalid condition');
+  });
+});

--- a/tests/query-builder.spec.ts
+++ b/tests/query-builder.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QueryBuilder } from '../src/builders/query-builder';
+import { ConditionBuilderImpl } from '../src/builders/condition-builder';
+
+function makeExec() {
+  return {
+    count: vi.fn().mockResolvedValue(2),
+    queryPage: vi.fn()
+      .mockResolvedValueOnce({ records: [{ id: 1 }], nextPage: 'n1' })
+      .mockResolvedValueOnce({ records: null })
+      .mockResolvedValue({ records: [], nextPage: null }),
+    update: vi.fn().mockResolvedValue('u'),
+    deleteByQuery: vi.fn().mockResolvedValue('d'),
+    stream: vi.fn().mockResolvedValue({ cancel: vi.fn() })
+  };
+}
+
+describe('QueryBuilder', () => {
+  it('builds queries and executes operations', async () => {
+    const exec = makeExec();
+    const qb = new QueryBuilder(exec as any, null);
+    const other = new ConditionBuilderImpl({ field: 'f', operator: '=', value: 6 });
+    qb.from('users')
+      .selectFields(['id'])
+      .selectFields([])
+      .resolve('rel1')
+      .resolve(['rel2'])
+      .where({ field: 'a', operator: '=', value: 1 })
+      .where({ field: 'b', operator: '=', value: 2 })
+      .and({ field: 'c', operator: '=', value: 3 })
+      .and({ field: 'd', operator: '=', value: 4 })
+      .and(other)
+      .or({ field: 'e', operator: '=', value: 5 })
+      .orderBy({ field: 'id', direction: 'asc' })
+      .groupBy('role')
+      .groupBy()
+      .distinct()
+      .limit(10)
+      .inPartition('p1')
+      .pageSize(5)
+      .nextPage('tok');
+
+    expect(await qb.count()).toBe(2);
+    expect(await qb.list()).toEqual([{ id: 1 }]);
+    expect(await qb.list()).toEqual([]);
+    await qb.page({ pageSize: 1, nextPage: 'x' });
+    expect(exec.queryPage).toHaveBeenLastCalledWith('users', expect.any(Object), { pageSize: 5, nextPage: 'tok', partition: 'p1' });
+    await qb.delete();
+    qb.onItemAdded(() => {}).onItemUpdated(() => {}).onItemDeleted(() => {}).onItem(() => {});
+    await qb.stream(false, true);
+    qb.setUpdates({ id: 1 });
+    await qb.update();
+  });
+
+  it('covers and/or branches', () => {
+    const exec = makeExec();
+    const a = new QueryBuilder(exec as any, 't');
+    a.and({ field: 'x', operator: '=', value: 1 });
+    a.and({ field: 'y', operator: '=', value: 2 });
+    a.and({ field: 'z', operator: '=', value: 3 });
+
+    const b = new QueryBuilder(exec as any, 't');
+    b.or({ field: 'x', operator: '=', value: 1 });
+    b.or({ field: 'y', operator: '=', value: 2 });
+    b.or({ field: 'z', operator: '=', value: 3 });
+    const c = new QueryBuilder(exec as any, 't');
+    c.where({ field: 'x', operator: '=', value: 1 }).or({ field: 'y', operator: '=', value: 2 });
+  });
+
+  it('handles defaults and undefined branches', async () => {
+    const exec = makeExec();
+    const qb = new QueryBuilder(exec as any, 't');
+    await qb.page();
+    await qb.stream();
+
+    const qbUpd = new QueryBuilder(exec as any, 't');
+    qbUpd.setUpdates(undefined as any);
+    await qbUpd.update();
+  });
+
+  it('throws on improper usage', async () => {
+    const exec = makeExec();
+    const qb = new QueryBuilder(exec as any, 'users');
+    await expect(qb.update()).rejects.toThrow('Call setUpdates(...) before update().');
+    qb.setUpdates({});
+    await expect(qb.count()).rejects.toThrow('Cannot call count() in update mode.');
+    await expect(qb.page()).rejects.toThrow('Cannot call page() in update mode.');
+    await expect(qb.delete()).rejects.toThrow('delete() is only applicable in select mode.');
+    await expect(qb.stream()).rejects.toThrow('Streaming is only applicable in select mode.');
+  });
+
+  it('validates table and conditions', async () => {
+    const exec = makeExec();
+    const qb = new QueryBuilder(exec as any, null);
+    await expect(qb.count()).rejects.toThrow('Table is not defined.');
+    qb.from('users');
+    expect(() => qb.where({} as any)).toThrow('Invalid condition passed to builder.');
+  });
+});

--- a/tests/save-builder.spec.ts
+++ b/tests/save-builder.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SaveBuilder } from '../src/builders/save-builder';
+
+describe('SaveBuilder', () => {
+  it('saves a single entity with and without relationships', async () => {
+    const save = vi.fn().mockResolvedValue('ok');
+    const db = { save } as any;
+    const builder = new SaveBuilder(db, 'Users');
+    await builder.one({ id: 1 });
+    expect(save).toHaveBeenCalledWith('Users', { id: 1 }, undefined);
+
+    builder.cascade('rel');
+    await builder.one({ id: 2 });
+    expect(save).toHaveBeenLastCalledWith('Users', { id: 2 }, { relationships: ['rel'] });
+  });
+
+  it('saves many entities with and without relationships', async () => {
+    const save = vi.fn().mockResolvedValue('ok');
+    const db = { save } as any;
+    const builder = new SaveBuilder(db, 'Users');
+    await builder.many([{ id: 1 }]);
+    expect(save).toHaveBeenCalledWith('Users', [{ id: 1 }], undefined);
+
+    builder.cascade('relA', 'relB');
+    await builder.many([{ id: 2 }, { id: 3 }]);
+    expect(save).toHaveBeenLastCalledWith('Users', [{ id: 2 }, { id: 3 }], { relationships: ['relA', 'relB'] });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for CascadeBuilder, SaveBuilder, ConditionBuilderImpl, and QueryBuilder to reach 100% coverage in src/builders
- document work in codex task and changelog

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aa8ebd7d088321b6430225a81d58f1