### PR TITLE
chore: run CI and tests only when relevant files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,25 @@ on:
   pull_request:
 
 jobs:
-  build:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            src:
+              - 'src/**'
+            tests:
+              - 'tests/**'
+
+  ci:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,5 +36,20 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
-      - run: npm test
       - run: npm run build
+
+  test:
+    needs: changes
+    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.tests == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/changelog/2025-08-23-0919pm-ci-path-filter.md
+++ b/changelog/2025-08-23-0919pm-ci-path-filter.md
@@ -1,0 +1,13 @@
+# Change: conditionally run CI and tests based on path changes
+
+- Date: 2025-08-23 09:19 PM PT
+- Author/Agent: ChatGPT
+- Scope: tooling
+- Type: chore
+- Summary:
+  - run CI job only when source files change
+  - execute tests when source or test files change
+- Impact:
+  - reduces unnecessary workflow executions
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- run CI build job only when source files change
- execute tests when source or test files change

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: MISSING DEPENDENCY Cannot find dependency '@vitest/coverage-v8')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa929bb9308321b10fc6cb55861192