### PR TITLE
docs: add examples epic tasks

### DIFF
--- a/changelog/2025-08-23-0928pm-add-examples-epic.md
+++ b/changelog/2025-08-23-0928pm-add-examples-epic.md
@@ -1,0 +1,12 @@
+# Change: add examples epic tasks
+
+- Date: 2025-08-23 09:28 PM PT
+- Author/Agent: ChatGPT
+- Scope: docs
+- Type: docs
+- Summary:
+  - add codex epic and tasks for examples of public API functions
+- Impact:
+  - documentation tracking only
+- Follow-ups:
+  - implement example tasks

--- a/codex/tasks/examples/001-init-example.md
+++ b/codex/tasks/examples/001-init-example.md
@@ -1,0 +1,6 @@
+# Task: Example for init
+
+Create an example demonstrating how to initialize the database using `init`.
+
+## Acceptance Criteria
+- [ ] An example is added under `examples/` showing use of `init` to create an `IOnyxDatabase` instance.

--- a/codex/tasks/examples/002-from-example.md
+++ b/codex/tasks/examples/002-from-example.md
@@ -1,0 +1,6 @@
+# Task: Example for from
+
+Create an example demonstrating the use of `from` to start a query for a table.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows querying a table using `from`.

--- a/codex/tasks/examples/003-select-example.md
+++ b/codex/tasks/examples/003-select-example.md
@@ -1,0 +1,6 @@
+# Task: Example for select
+
+Create an example demonstrating the use of `select` to specify fields in a query.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows selecting fields with `select`.

--- a/codex/tasks/examples/004-cascade-example.md
+++ b/codex/tasks/examples/004-cascade-example.md
@@ -1,0 +1,6 @@
+# Task: Example for cascade
+
+Create an example demonstrating the use of `cascade` to include related records.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows chaining `cascade` to load relationships.

--- a/codex/tasks/examples/005-save-example.md
+++ b/codex/tasks/examples/005-save-example.md
@@ -1,0 +1,6 @@
+# Task: Example for save
+
+Create an example demonstrating how to persist data using `save`.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows saving data with `save`.

--- a/codex/tasks/examples/006-find-by-id-example.md
+++ b/codex/tasks/examples/006-find-by-id-example.md
@@ -1,0 +1,6 @@
+# Task: Example for findById
+
+Create an example demonstrating how to retrieve a record by its primary key using `findById`.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows fetching a record with `findById`.

--- a/codex/tasks/examples/007-delete-example.md
+++ b/codex/tasks/examples/007-delete-example.md
@@ -1,0 +1,6 @@
+# Task: Example for delete
+
+Create an example demonstrating how to remove a record using `delete`.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows deleting a record with `delete`.

--- a/codex/tasks/examples/008-save-document-example.md
+++ b/codex/tasks/examples/008-save-document-example.md
@@ -1,0 +1,6 @@
+# Task: Example for saveDocument
+
+Create an example demonstrating how to store a document using `saveDocument`.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows saving a document with `saveDocument`.

--- a/codex/tasks/examples/009-get-document-example.md
+++ b/codex/tasks/examples/009-get-document-example.md
@@ -1,0 +1,6 @@
+# Task: Example for getDocument
+
+Create an example demonstrating how to fetch a document using `getDocument`.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows retrieving a document with `getDocument`.

--- a/codex/tasks/examples/010-delete-document-example.md
+++ b/codex/tasks/examples/010-delete-document-example.md
@@ -1,0 +1,6 @@
+# Task: Example for deleteDocument
+
+Create an example demonstrating how to remove a document using `deleteDocument`.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows deleting a document with `deleteDocument`.


### PR DESCRIPTION
## Summary
- add `examples` codex epic with tasks for each public API method (except `close`)
- document change in changelog

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa94c4a8a48321811380a5bc7ca454