### PR TITLE
chore: add security policy and dependency monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: "/examples"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
+      - run: npm run audit
       - run: npm run lint
       - run: npm test -- --coverage
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ This repository uses [Changesets](https://github.com/changesets/changesets) for 
 
 ---
 
+## Security
+
+See [SECURITY.md](./SECURITY.md) for our security policy and vulnerability reporting process.
+
+---
+
 ## License
 
 Apache-2.0 © Onyx Dev Tools

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue, please email security@onyx.dev with detailed information. We will respond within 3 business days.
+
+## Supported Versions
+
+Security fixes are applied to the latest major release of `@onyx.dev/onyx-database`.

--- a/changelog/2025-08-24-0437am-security-audit.md
+++ b/changelog/2025-08-24-0437am-security-audit.md
@@ -1,0 +1,14 @@
+# Change: add security policy and dependency monitoring
+
+- Date: 2025-08-24 04:37 AM UTC
+- Author/Agent: ChatGPT
+- Scope: tooling
+- Type: chore
+- Summary:
+  - configure Dependabot for weekly npm checks
+  - add security audit to CI pipeline
+  - document vulnerability reporting in SECURITY.md and link from README
+- Impact:
+  - improves repository security posture without affecting runtime behavior
+- Follow-ups:
+  - none

--- a/codex/tasks/library-readiness/finished/005-security-audit.md
+++ b/codex/tasks/library-readiness/finished/005-security-audit.md
@@ -16,5 +16,5 @@ Baseline security posture.
 4. Link `SECURITY.md` from `README.md`.
 
 ## Acceptance Criteria
-- [ ] Dependabot opens PRs for outdated deps.
-- [ ] `SECURITY.md` present and linked in README.
+- [x] Dependabot opens PRs for outdated deps.
+- [x] `SECURITY.md` present and linked in README.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "tsup",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
+    "audit": "npm audit --audit-level=high",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepublishOnly": "npm run build && npm run typecheck",


### PR DESCRIPTION
## Summary
- configure Dependabot for weekly npm updates in core and examples
- run `npm run audit` in CI to catch high severity vulnerabilities
- document vulnerability reporting in SECURITY.md and link from README

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run audit`


------
https://chatgpt.com/codex/tasks/task_e_68aa968c7dd483219cc882b8ec22c996