### PR TITLE
docs: plan examples tasks

### DIFF
--- a/changelog/2025-08-24-0438am-plan-examples.md
+++ b/changelog/2025-08-24-0438am-plan-examples.md
@@ -1,0 +1,12 @@
+# Change: plan examples tasks
+
+- Date: 2025-08-24 04:38 AM UTC
+- Author/Agent: OpenAI Assistant
+- Scope: docs
+- Type: docs
+- Summary:
+  - Added planning documents for examples epic tasks.
+- Impact:
+  - Documentation only; no code changes.
+- Follow-ups:
+  - Implement examples according to plans.

--- a/codex/tasks/examples/001-init-example.md
+++ b/codex/tasks/examples/001-init-example.md
@@ -1,6 +1,0 @@
-# Task: Example for init
-
-Create an example demonstrating how to initialize the database using `init`.
-
-## Acceptance Criteria
-- [ ] An example is added under `examples/` showing use of `init` to create an `IOnyxDatabase` instance.

--- a/codex/tasks/examples/004-cascade-example.md
+++ b/codex/tasks/examples/004-cascade-example.md
@@ -1,6 +1,0 @@
-# Task: Example for cascade
-
-Create an example demonstrating the use of `cascade` to include related records.
-
-## Acceptance Criteria
-- [ ] An example under `examples/` shows chaining `cascade` to load relationships.

--- a/codex/tasks/examples/005-save-example.md
+++ b/codex/tasks/examples/005-save-example.md
@@ -1,6 +1,0 @@
-# Task: Example for save
-
-Create an example demonstrating how to persist data using `save`.
-
-## Acceptance Criteria
-- [ ] An example under `examples/` shows saving data with `save`.

--- a/codex/tasks/examples/007-delete-example.md
+++ b/codex/tasks/examples/007-delete-example.md
@@ -1,6 +1,0 @@
-# Task: Example for delete
-
-Create an example demonstrating how to remove a record using `delete`.
-
-## Acceptance Criteria
-- [ ] An example under `examples/` shows deleting a record with `delete`.

--- a/codex/tasks/examples/008-save-document-example.md
+++ b/codex/tasks/examples/008-save-document-example.md
@@ -1,6 +1,0 @@
-# Task: Example for saveDocument
-
-Create an example demonstrating how to store a document using `saveDocument`.
-
-## Acceptance Criteria
-- [ ] An example under `examples/` shows saving a document with `saveDocument`.

--- a/codex/tasks/examples/plan/001-init-example-plan.md
+++ b/codex/tasks/examples/plan/001-init-example-plan.md
@@ -1,0 +1,11 @@
+# Task: Example for init
+
+Create an example demonstrating how to initialize the database using `init`.
+
+## Plan
+1. Add `examples/init/basic.ts` illustrating `init` creating an `IOnyxDatabase` instance.
+2. Configure minimal connection parameters suitable for a runnable example.
+3. Log a simple operation to verify the client initializes successfully.
+
+## Acceptance Criteria
+- [ ] An example is added under `examples/` showing use of `init` to create an `IOnyxDatabase` instance.

--- a/codex/tasks/examples/plan/002-from-example-plan.md
+++ b/codex/tasks/examples/plan/002-from-example-plan.md
@@ -2,5 +2,10 @@
 
 Create an example demonstrating the use of `from` to start a query for a table.
 
+## Plan
+1. Add `examples/query/from.ts` showing `db.from('table')` to begin a query.
+2. Use a sample table name and log the returned builder.
+3. Confirm the example compiles using the SDK's types.
+
 ## Acceptance Criteria
 - [ ] An example under `examples/` shows querying a table using `from`.

--- a/codex/tasks/examples/plan/003-select-example-plan.md
+++ b/codex/tasks/examples/plan/003-select-example-plan.md
@@ -2,5 +2,10 @@
 
 Create an example demonstrating the use of `select` to specify fields in a query.
 
+## Plan
+1. Add `examples/query/select.ts` showing `.select(['id', 'name'])` after `.from('table')`.
+2. Execute the query and print the selected fields.
+3. Ensure types reflect the narrowed field selection.
+
 ## Acceptance Criteria
 - [ ] An example under `examples/` shows selecting fields with `select`.

--- a/codex/tasks/examples/plan/004-cascade-example-plan.md
+++ b/codex/tasks/examples/plan/004-cascade-example-plan.md
@@ -1,0 +1,11 @@
+# Task: Example for cascade
+
+Create an example demonstrating the use of `cascade` to include related records.
+
+## Plan
+1. Add `examples/query/cascade.ts` showing `.cascade('relation')` on a query builder.
+2. Use sample tables with a defined relationship to demonstrate cascading.
+3. Output parent and related records to confirm loading behavior.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows chaining `cascade` to load relationships.

--- a/codex/tasks/examples/plan/005-save-example-plan.md
+++ b/codex/tasks/examples/plan/005-save-example-plan.md
@@ -1,0 +1,11 @@
+# Task: Example for save
+
+Create an example demonstrating how to persist data using `save`.
+
+## Plan
+1. Add `examples/save/save.ts` inserting a sample record via `db.save()`.
+2. Show handling of returned saved entity for confirmation.
+3. Include comments describing required fields.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows saving data with `save`.

--- a/codex/tasks/examples/plan/006-find-by-id-example-plan.md
+++ b/codex/tasks/examples/plan/006-find-by-id-example-plan.md
@@ -2,5 +2,10 @@
 
 Create an example demonstrating how to retrieve a record by its primary key using `findById`.
 
+## Plan
+1. Add `examples/query/find-by-id.ts` showing `db.from('table').findById(id)`.
+2. Use a placeholder ID and log the retrieved record.
+3. Illustrate error handling when no record is found.
+
 ## Acceptance Criteria
 - [ ] An example under `examples/` shows fetching a record with `findById`.

--- a/codex/tasks/examples/plan/007-delete-example-plan.md
+++ b/codex/tasks/examples/plan/007-delete-example-plan.md
@@ -1,0 +1,11 @@
+# Task: Example for delete
+
+Create an example demonstrating how to remove a record using `delete`.
+
+## Plan
+1. Add `examples/delete/basic.ts` executing `db.from('table').delete().where('id', id)`.
+2. Print confirmation of the deletion count.
+3. Include notes on cascading or dependent records if applicable.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows deleting a record with `delete`.

--- a/codex/tasks/examples/plan/008-save-document-example-plan.md
+++ b/codex/tasks/examples/plan/008-save-document-example-plan.md
@@ -1,0 +1,11 @@
+# Task: Example for saveDocument
+
+Create an example demonstrating how to store a document using `saveDocument`.
+
+## Plan
+1. Create directory `examples/document/` if needed and add `save-document.ts`.
+2. Demonstrate writing a JSON document via `db.saveDocument(collection, id, doc)`.
+3. Log the stored document metadata to confirm success.
+
+## Acceptance Criteria
+- [ ] An example under `examples/` shows saving a document with `saveDocument`.

--- a/codex/tasks/examples/plan/009-get-document-example-plan.md
+++ b/codex/tasks/examples/plan/009-get-document-example-plan.md
@@ -2,5 +2,10 @@
 
 Create an example demonstrating how to fetch a document using `getDocument`.
 
+## Plan
+1. Add `examples/document/get-document.ts` reading a document via `db.getDocument(collection, id)`.
+2. Log the fetched document contents.
+3. Show handling when the document is missing.
+
 ## Acceptance Criteria
 - [ ] An example under `examples/` shows retrieving a document with `getDocument`.

--- a/codex/tasks/examples/plan/010-delete-document-example-plan.md
+++ b/codex/tasks/examples/plan/010-delete-document-example-plan.md
@@ -2,5 +2,10 @@
 
 Create an example demonstrating how to remove a document using `deleteDocument`.
 
+## Plan
+1. Add `examples/document/delete-document.ts` invoking `db.deleteDocument(collection, id)`.
+2. Print confirmation that the document was deleted.
+3. Include a note about idempotency or non-existent documents.
+
 ## Acceptance Criteria
 - [ ] An example under `examples/` shows deleting a document with `deleteDocument`.


### PR DESCRIPTION
## Summary
- plan example tasks for init, queries, saves, deletes, and document operations
- add changelog entry

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa96ddfacc83219fb8998d1f9e1355