### PR TITLE
docs: add code of conduct and contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a bug in @onyx.dev/onyx-database
+title: "[bug] "
+labels: bug
+assignees: ''
+---
+
+### Describe the bug
+
+A clear and concise description of what the bug is.
+
+### To Reproduce
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+### Expected behavior
+
+What you expected to happen.
+
+### Environment
+
+- OS:
+- Node version:
+- Package version:
+
+### Additional context
+
+Add any other context about the problem here.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for @onyx.dev/onyx-database
+title: "[feat] "
+labels: enhancement
+assignees: ''
+---
+
+### Describe the feature
+
+A clear and concise description of the feature you'd like.
+
+### Why is this needed?
+
+What problem does this solve?
+
+### Alternatives considered
+
+Describe any alternative solutions you've considered.
+
+### Additional context
+
+Add any other context or screenshots about the feature request here.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+# Summary
+
+Describe the changes in this pull request.
+
+# Testing
+
+- [ ] `npm run typecheck`
+- [ ] `npm run build`
+- [ ] `npm test`
+
+# Changelog
+
+- [ ] Added entry under `changelog/`
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+oss@onyx.dev.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Thanks for your interest in contributing! This project is a **zero-dependency**,
 
 ## Code of conduct
 
-Be respectful and constructive. We welcome issues and PRs that improve the SDK, developer experience, or documentation.
+Be respectful and constructive. We welcome issues and PRs that improve the SDK, developer experience, or documentation. See the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for full guidelines.
 
 ---
 

--- a/changelog/2025-08-23-0948pm-contributing-templates.md
+++ b/changelog/2025-08-23-0948pm-contributing-templates.md
@@ -1,0 +1,14 @@
+# Change: add contributing templates and code of conduct
+
+- Date: 2025-08-23 09:48 PM PT
+- Author/Agent: ChatGPT
+- Scope: docs
+- Type: docs
+- Summary:
+  - add issue and PR templates for GitHub
+  - add Contributor Covenant Code of Conduct
+- Impact:
+  - repo becomes more contributor friendly
+- Follow-ups:
+  - none
+

--- a/codex/tasks/library-readiness/finished/006-contributing-templates.md
+++ b/codex/tasks/library-readiness/finished/006-contributing-templates.md
@@ -17,5 +17,5 @@ Contributor-friendly repo.
 5. Commit templates and ensure GitHub recognizes them.
 
 ## Acceptance Criteria
-- [ ] New issues/PRs use templates.
-- [ ] CONTRIBUTING explains tooling and release flow.
+- [x] New issues/PRs use templates.
+- [x] CONTRIBUTING explains tooling and release flow.


### PR DESCRIPTION
## Summary
- add Contributor Covenant code of conduct
- add issue and PR templates for community contributions
- link CONTRIBUTING to new conduct guidelines and document in codex

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9974c18c83218feffae5743e982f