### PR TITLE
docs: add init, from, and select examples

### DIFF
--- a/changelog/2025-08-24-0450am-init-from-select-examples.md
+++ b/changelog/2025-08-24-0450am-init-from-select-examples.md
@@ -1,0 +1,14 @@
+# Change: add init, from, and select examples
+
+- Date: 2025-08-24 04:50 AM UTC
+- Author/Agent: assistant
+- Scope: examples
+- Type: docs
+- Summary:
+  - add basic init example for creating an IOnyxDatabase instance
+  - demonstrate starting a query with from
+  - show selecting specific fields with select
+- Impact:
+  - provides reference usage for core query functions
+- Follow-ups:
+  - none

--- a/codex/tasks/examples/finished/001-init-example.md
+++ b/codex/tasks/examples/finished/001-init-example.md
@@ -8,4 +8,4 @@ Create an example demonstrating how to initialize the database using `init`.
 3. Log a simple operation to verify the client initializes successfully.
 
 ## Acceptance Criteria
-- [ ] An example is added under `examples/` showing use of `init` to create an `IOnyxDatabase` instance.
+- [x] An example is added under `examples/` showing use of `init` to create an `IOnyxDatabase` instance.

--- a/codex/tasks/examples/finished/002-from-example.md
+++ b/codex/tasks/examples/finished/002-from-example.md
@@ -8,4 +8,4 @@ Create an example demonstrating the use of `from` to start a query for a table.
 3. Confirm the example compiles using the SDK's types.
 
 ## Acceptance Criteria
-- [ ] An example under `examples/` shows querying a table using `from`.
+- [x] An example under `examples/` shows querying a table using `from`.

--- a/codex/tasks/examples/finished/003-select-example.md
+++ b/codex/tasks/examples/finished/003-select-example.md
@@ -8,4 +8,4 @@ Create an example demonstrating the use of `select` to specify fields in a query
 3. Ensure types reflect the narrowed field selection.
 
 ## Acceptance Criteria
-- [ ] An example under `examples/` shows selecting fields with `select`.
+- [x] An example under `examples/` shows selecting fields with `select`.

--- a/examples/init/basic.ts
+++ b/examples/init/basic.ts
@@ -1,0 +1,19 @@
+// filename: examples/init/basic.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+import { Schema } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>({
+    project: 'demo',
+    branch: 'main',
+    token: 'test-token',
+  });
+
+  console.log('Initialized Onyx client:', typeof db);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/query/from.ts
+++ b/examples/query/from.ts
@@ -1,0 +1,17 @@
+// filename: examples/query/from.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+import { tables, Schema } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const builder = db.from(tables.VodItem);
+  console.log('Query builder initialized for table:', tables.VodItem);
+  console.log(builder);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/query/select.ts
+++ b/examples/query/select.ts
@@ -1,0 +1,20 @@
+// filename: examples/query/select.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+import { tables, Schema } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const items = await db
+    .from(tables.VodItem)
+    .select(['id', 'title'])
+    .list();
+
+  console.log(items);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add basic init example for creating an `IOnyxDatabase` instance
- demonstrate starting a query with `from`
- show selecting specific fields using `select`

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run gen:onyx`
- `npm start` *(fails: Missing script "start")*


------
https://chatgpt.com/codex/tasks/task_e_68aa999c7bb08321aceb406181101c01