### PR TITLE
chore: tidy package.json metadata

### DIFF
--- a/changelog/2025-08-23-1004pm-package-json-hygiene.md
+++ b/changelog/2025-08-23-1004pm-package-json-hygiene.md
@@ -1,0 +1,13 @@
+# Change: package.json hygiene
+
+- Date: 2025-08-23 10:04 PM PT
+- Author/Agent: OpenAI Assistant
+- Scope: tooling
+- Type: chore
+- Summary:
+  - add missing metadata fields to package.json
+  - whitelist release files to ensure clean package
+- Impact:
+  - improves published package metadata and contents
+- Follow-ups:
+  - none

--- a/codex/tasks/library-readiness/finished/008-package-json-hygiene.md
+++ b/codex/tasks/library-readiness/finished/008-package-json-hygiene.md
@@ -19,4 +19,4 @@ Accurate metadata and clean publish.
 5. Commit updates to `package.json`.
 
 ## Acceptance Criteria
-- [ ] `npm pack --dry-run` shows only intended files (dist, src if desired, docs if desired, root meta).
+- [x] `npm pack --dry-run` shows only intended files (dist, src if desired, docs if desired, root meta).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "@onyx.dev/onyx-database",
   "version": "0.1.0",
   "description": "TypeScript client SDK for Onyx Database",
+  "keywords": [
+    "database",
+    "sdk",
+    "onyx"
+  ],
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -17,7 +22,9 @@
     "onyx-gen": "./dist/gen/cli/generate.cjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "sideEffects": false,
   "scripts": {
@@ -33,6 +40,11 @@
     "release": "changeset publish"
   },
   "repository": "github:OnyxDevTools/onyx-database",
+  "bugs": {
+    "url": "https://github.com/OnyxDevTools/onyx-database/issues"
+  },
+  "homepage": "https://github.com/OnyxDevTools/onyx-database#readme",
+  "author": "Onyx DevTools",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- add missing package metadata fields and whitelist release files
- record completion of package.json hygiene task

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm pack --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68aa9cfed1208321895dee19ee04a3cc