### PR TITLE
feat: add delete and document examples

### DIFF
--- a/changelog/2025-08-23-0935pm-document-examples.md
+++ b/changelog/2025-08-23-0935pm-document-examples.md
@@ -1,0 +1,13 @@
+# Change: add delete and document examples
+
+- Date: 2025-08-23 09:35 PM PT
+- Author/Agent: ChatGPT
+- Scope: examples
+- Type: feat
+- Summary:
+  - Added record deletion example using query builder.
+  - Added examples for saving, fetching, and deleting documents.
+- Impact:
+  - Provides guidance for delete and document APIs.
+- Follow-ups:
+  - none

--- a/codex/tasks/examples/finished/007-delete-example.md
+++ b/codex/tasks/examples/finished/007-delete-example.md
@@ -8,4 +8,4 @@ Create an example demonstrating how to remove a record using `delete`.
 3. Include notes on cascading or dependent records if applicable.
 
 ## Acceptance Criteria
-- [ ] An example under `examples/` shows deleting a record with `delete`.
+- [x] An example under `examples/` shows deleting a record with `delete`.

--- a/codex/tasks/examples/finished/008-save-document-example.md
+++ b/codex/tasks/examples/finished/008-save-document-example.md
@@ -8,4 +8,4 @@ Create an example demonstrating how to store a document using `saveDocument`.
 3. Log the stored document metadata to confirm success.
 
 ## Acceptance Criteria
-- [ ] An example under `examples/` shows saving a document with `saveDocument`.
+- [x] An example under `examples/` shows saving a document with `saveDocument`.

--- a/codex/tasks/examples/finished/009-get-document-example.md
+++ b/codex/tasks/examples/finished/009-get-document-example.md
@@ -8,4 +8,4 @@ Create an example demonstrating how to fetch a document using `getDocument`.
 3. Show handling when the document is missing.
 
 ## Acceptance Criteria
-- [ ] An example under `examples/` shows retrieving a document with `getDocument`.
+- [x] An example under `examples/` shows retrieving a document with `getDocument`.

--- a/codex/tasks/examples/finished/010-delete-document-example.md
+++ b/codex/tasks/examples/finished/010-delete-document-example.md
@@ -8,4 +8,4 @@ Create an example demonstrating how to remove a document using `deleteDocument`.
 3. Include a note about idempotency or non-existent documents.
 
 ## Acceptance Criteria
-- [ ] An example under `examples/` shows deleting a document with `deleteDocument`.
+- [x] An example under `examples/` shows deleting a document with `deleteDocument`.

--- a/examples/delete/basic.ts
+++ b/examples/delete/basic.ts
@@ -1,0 +1,20 @@
+// filename: examples/delete/basic.ts
+import process from 'node:process';
+import { onyx, eq } from '@onyx.dev/onyx-database';
+import { tables, Schema } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const deleted = (await db
+    .from(tables.VodItem)
+    .where(eq('streamId', 1))
+    .delete()) as number;
+
+  console.log(`Deleted ${deleted} record(s).`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/document/delete-document.ts
+++ b/examples/document/delete-document.ts
@@ -1,0 +1,15 @@
+// filename: examples/document/delete-document.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+
+async function main(): Promise<void> {
+  const db = onyx.init();
+
+  await db.deleteDocument('note.json');
+  console.log('Document deleted (no-op if it did not exist).');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/document/get-document.ts
+++ b/examples/document/get-document.ts
@@ -1,0 +1,19 @@
+// filename: examples/document/get-document.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+
+async function main(): Promise<void> {
+  const db = onyx.init();
+
+  try {
+    const doc = await db.getDocument('note.json');
+    console.log('Document contents:', doc);
+  } catch {
+    console.log('Document not found.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/document/save-document.ts
+++ b/examples/document/save-document.ts
@@ -1,0 +1,23 @@
+// filename: examples/document/save-document.ts
+import process from 'node:process';
+import { Buffer } from 'node:buffer';
+import { onyx, type OnyxDocument } from '@onyx.dev/onyx-database';
+
+async function main(): Promise<void> {
+  const db = onyx.init();
+
+  const doc: OnyxDocument = {
+    documentId: 'note.json',
+    path: '/notes/note.json',
+    mimeType: 'application/json',
+    content: Buffer.from(JSON.stringify({ message: 'hello' })).toString('base64'),
+  };
+
+  const meta = await db.saveDocument(doc);
+  console.log('Saved document:', meta);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -13,5 +13,11 @@
     "noEmit": false,
     "baseUrl": "."
   },
-  "include": ["query/**/*.ts", "generated/**/*.ts"]
+  "include": [
+    "query/**/*.ts",
+    "save/**/*.ts",
+    "delete/**/*.ts",
+    "document/**/*.ts",
+    "onyx/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- add example for deleting records via query builder
- demonstrate saving, fetching and deleting documents
- update examples tsconfig and codex task statuses

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`
- `cd examples && npm run gen:onyx`
- `cd examples && npm start` *(fails: Missing script "start")*

------
https://chatgpt.com/codex/tasks/task_e_68aa9d0e5ad48321913c7c52d46f08c5