### PR TITLE
fix: return deleted entity from cascade delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,12 @@ await db.cascade('User.Role').save('User', {
 import { onyx } from '@onyx.dev/onyx-database';
 const db = onyx.init();
 
-// Simple delete
-await db.delete('User', 'user_125');
+// Simple delete returns the removed record
+const removed = await db.delete('User', 'user_125');
 
 // Delete cascading relationships (example)
-await db.delete('Role', 'role_temp', { relationships: ['Role.Permission'] });
+const role = await db.delete('Role', 'role_temp', { relationships: ['Role.Permission'] });
+// role includes cascaded relationships
 ```
 
 ### 4) Documents API (binary assets)

--- a/changelog/2025-08-23-1156pm-cascade-delete-response.md
+++ b/changelog/2025-08-23-1156pm-cascade-delete-response.md
@@ -1,0 +1,13 @@
+# Change: fix cascade delete returns entity
+
+- Date: 2025-08-23 11:56 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Add `Accept: application/json` header so delete responses include body.
+  - Update delete methods to return the removed record.
+- Impact:
+  - `delete()` now resolves with the deleted entity and requested relationships.
+- Follow-ups:
+  - none

--- a/codex/tasks/library-readiness/finished/015-cascade-delete-response.md
+++ b/codex/tasks/library-readiness/finished/015-cascade-delete-response.md
@@ -1,0 +1,26 @@
+# Task: Fix cascade delete response
+
+## Goal
+Ensure cascade delete returns deleted entity including requested relationships.
+
+## Steps
+1. Add `Accept: application/json` header to all HTTP requests.
+2. Update IOnyxDatabase and CascadeBuilder delete methods to return typed entity.
+3. Adjust README example to capture delete response.
+4. Cover new header in tests.
+5. Record changelog entry.
+
+# Plan: Fix cascade delete response
+1. Modify `src/core/http.ts` headers to include `Accept: application/json`.
+2. Update `src/types/public.ts` and `src/impl/onyx.ts` to type `delete` return value.
+3. Adjust `src/builders/cascade-builder.ts` to return typed `delete`.
+4. Update `tests/http-client.spec.ts` expectations for `Accept` header and add DELETE case.
+5. Revise README delete example to show returned record.
+6. Add changelog entry under `changelog/`.
+7. Run `npm run typecheck`, `npm test`, `npm run build`.
+
+## Acceptance Criteria
+- [x] HttpClient sends `Accept: application/json`.
+- [x] `delete` methods return parsed JSON.
+- [x] README reflects delete response.
+- [x] Tests, typecheck, and build succeed.

--- a/src/builders/cascade-builder.ts
+++ b/src/builders/cascade-builder.ts
@@ -30,9 +30,12 @@ export class CascadeBuilder<Schema = Record<string, unknown>> implements ICascad
     );
   }
 
-  delete(table: string, primaryKey: string): Promise<unknown> {
+  delete<Table extends keyof Schema & string>(
+    table: Table,
+    primaryKey: string,
+  ): Promise<Schema[Table]> {
     const opts = this.relationships.length ? { relationships: this.relationships } : undefined;
-    return this.db.delete(String(table), primaryKey, opts);
+    return this.db.delete(table, primaryKey, opts);
   }
 }
 

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -45,6 +45,7 @@ export class HttpClient {
     return {
       'x-onyx-key': this.apiKey,
       'x-onyx-secret': this.apiSecret,
+      'Accept': 'application/json',
       'Content-Type': 'application/json',
       ...this.defaults,
       ...(extra ?? {})

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -142,11 +142,11 @@ class OnyxDatabaseImpl<Schema = Record<string, unknown>> implements IOnyxDatabas
     return http.request<T>('GET', path);
   }
 
-  async delete(
-    table: string,
+  async delete<Table extends keyof Schema & string, T = Schema[Table]>(
+    table: Table,
     primaryKey: string,
     options?: { partition?: string; relationships?: string[] },
-  ): Promise<unknown> {
+  ): Promise<T> {
     const { http, databaseId } = await this.ensureClient();
     const params = new URLSearchParams();
     if (options?.partition) params.append('partition', options.partition);
@@ -156,7 +156,7 @@ class OnyxDatabaseImpl<Schema = Record<string, unknown>> implements IOnyxDatabas
     const path = `/data/${encodeURIComponent(databaseId)}/${encodeURIComponent(
       table,
     )}/${encodeURIComponent(primaryKey)}${params.toString() ? `?${params.toString()}` : ''}`;
-    return http.request('DELETE', path);
+    return http.request<T>('DELETE', path);
   }
 
   async saveDocument(doc: OnyxDocument): Promise<unknown> {
@@ -590,7 +590,10 @@ class CascadeBuilderImpl<Schema = Record<string, unknown>>
     });
   }
 
-  delete(table: string, primaryKey: string): Promise<unknown> {
+  delete<Table extends keyof Schema & string>(
+    table: Table,
+    primaryKey: string,
+  ): Promise<Schema[Table]> {
     return this.db.delete(table, primaryKey, { relationships: this.rels ?? undefined });
   }
 }

--- a/src/types/builders.ts
+++ b/src/types/builders.ts
@@ -51,5 +51,8 @@ export interface ICascadeBuilder<Schema = Record<string, unknown>> {
     table: Table,
     entityOrEntities: Partial<Schema[Table]> | Array<Partial<Schema[Table]>>
   ): Promise<unknown>;
-  delete(table: string, primaryKey: string): Promise<unknown>;
+  delete<Table extends keyof Schema & string>(
+    table: Table,
+    primaryKey: string,
+  ): Promise<Schema[Table]>;
 }

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -28,11 +28,11 @@ export interface IOnyxDatabase<Schema = Record<string, unknown>> {
     options?: { partition?: string; resolvers?: string[] }
   ): Promise<T>;
 
-  delete(
-    table: string,
+  delete<Table extends keyof Schema & string, T = Schema[Table]>(
+    table: Table,
     primaryKey: string,
     options?: { partition?: string; relationships?: string[] }
-  ): Promise<unknown>;
+  ): Promise<T>;
 
   saveDocument(doc: OnyxDocument): Promise<unknown>;
   getDocument(documentId: string, options?: { width?: number; height?: number }): Promise<unknown>;

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -33,6 +33,7 @@ describe('HttpClient', () => {
       headers: {
         'x-onyx-key': creds.apiKey,
         'x-onyx-secret': creds.apiSecret,
+        Accept: 'application/json',
         'Content-Type': 'application/json',
         'X-Custom': 'y'
       },
@@ -54,10 +55,33 @@ describe('HttpClient', () => {
       headers: {
         'x-onyx-key': creds.apiKey,
         'x-onyx-secret': creds.apiSecret,
+        Accept: 'application/json',
         'Content-Type': 'application/json'
       },
       body: '{"x":1}'
     });
+  });
+
+  it('includes Accept header on DELETE and parses JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+    const client = new HttpClient({ baseUrl: base, ...creds, fetchImpl: fetchMock });
+    const res = await client.request('DELETE', '/thing');
+    expect(fetchMock).toHaveBeenCalledWith(`${base}/thing`, {
+      method: 'DELETE',
+      headers: {
+        'x-onyx-key': creds.apiKey,
+        'x-onyx-secret': creds.apiSecret,
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: undefined
+    });
+    expect(res).toEqual({ ok: true });
   });
 
   it('uses global fetch when none provided', async () => {


### PR DESCRIPTION
## Summary
- ensure HTTP client sends `Accept: application/json`
- type cascade delete to return removed record and update docs
- add tests confirming Accept header and delete parsing

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aab6ff470483218d2fc8f314237f16