### PR TITLE
fix: return deleted entity graph

### DIFF
--- a/changelog/2025-08-24-0705am-delete-graph.md
+++ b/changelog/2025-08-24-0705am-delete-graph.md
@@ -1,0 +1,13 @@
+# Change: ensure delete returns entity graph
+
+- Date: 2025-08-24 12:05 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Send `Prefer: return=representation` header on DELETE requests so the API returns deleted records.
+  - Update HTTP client tests for new header.
+- Impact:
+  - Delete operations now resolve with the removed entity and requested relationships.
+- Follow-ups:
+  - none

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -59,9 +59,13 @@ export class HttpClient {
     extraHeaders?: Record<string, string>
   ): Promise<T> {
     const url = `${this.baseUrl}${path}`;
+    const headers = this.headers({
+      ...(method === 'DELETE' ? { Prefer: 'return=representation' } : {}),
+      ...(extraHeaders ?? {}),
+    });
     const init = {
       method,
-      headers: this.headers(extraHeaders),
+      headers,
       body: body == null ? undefined : (typeof body === 'string' ? body : JSON.stringify(body))
     };
     const res = await this.fetchImpl(url, init);

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -19,6 +19,16 @@ describe('HttpClient', () => {
   const base = 'https://api.test';
   const creds = { apiKey: 'k', apiSecret: 's' };
 
+  it('returns default headers without extras', () => {
+    const client = new HttpClient({ baseUrl: base, ...creds, fetchImpl: vi.fn() });
+    expect(client.headers()).toEqual({
+      'x-onyx-key': creds.apiKey,
+      'x-onyx-secret': creds.apiSecret,
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    });
+  });
+
   it('uses provided fetch and returns parsed JSON', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {
@@ -77,7 +87,8 @@ describe('HttpClient', () => {
         'x-onyx-key': creds.apiKey,
         'x-onyx-secret': creds.apiSecret,
         Accept: 'application/json',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation'
       },
       body: undefined
     });


### PR DESCRIPTION
## Summary
- send `Prefer: return=representation` header on DELETE
- test and document cascaded delete responses

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm --prefix examples run gen:onyx`
- `node --import=tsx --enable-source-maps save/cascade.ts` *(fails: Missing required config: databaseId, apiKey, apiSecret)*

------
https://chatgpt.com/codex/tasks/task_e_68aab9557b508321a84d50501cc12337