### PR TITLE
fix: return body for delete responses

### DIFF
--- a/changelog/2025-08-24-0820am-delete-response-body.md
+++ b/changelog/2025-08-24-0820am-delete-response-body.md
@@ -1,0 +1,13 @@
+# Change: return body for DELETE responses
+
+- Date: 2025-08-24 08:20 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Avoid sending `Content-Type` when no request body is present so DELETE responses can include JSON payloads.
+  - Update tests to reflect header omission.
+- Impact:
+  - DELETE operations now return server-provided entities instead of empty strings.
+- Follow-ups:
+  - none

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -63,6 +63,7 @@ export class HttpClient {
       ...(method === 'DELETE' ? { Prefer: 'return=representation' } : {}),
       ...(extraHeaders ?? {}),
     });
+    if (body == null) delete headers['Content-Type'];
     const init = {
       method,
       headers,

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -72,7 +72,7 @@ describe('HttpClient', () => {
     });
   });
 
-  it('includes Accept header on DELETE and parses JSON', async () => {
+  it('sends Prefer header on DELETE and parses JSON', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {
         status: 200,
@@ -87,7 +87,6 @@ describe('HttpClient', () => {
         'x-onyx-key': creds.apiKey,
         'x-onyx-secret': creds.apiSecret,
         Accept: 'application/json',
-        'Content-Type': 'application/json',
         Prefer: 'return=representation'
       },
       body: undefined


### PR DESCRIPTION
## Summary
- avoid sending `Content-Type` header when request has no body so DELETE calls can return entities
- adjust http client tests for header omission

## Testing
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aabd345b4c8321ad403ace2b0833cc