### PR TITLE
fix: parse delete body without content-type

### DIFF
--- a/changelog/2025-08-24-0905am-delete-json-parse.md
+++ b/changelog/2025-08-24-0905am-delete-json-parse.md
@@ -1,0 +1,13 @@
+# Change: parse JSON delete body without content-type
+
+- Date: 2025-08-24 09:05 AM PT
+- Author/Agent: OpenAI ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Parse delete responses as JSON when body looks like JSON but lacks content-type
+  - Ensures cascade delete returns entity graph
+- Impact:
+  - More reliable delete responses with missing content-type
+- Follow-ups:
+  - none

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -72,7 +72,10 @@ export class HttpClient {
     const res = await this.fetchImpl(url, init);
     const contentType = res.headers.get('Content-Type') || '';
     const raw = await res.text();
-    const data = contentType.includes('application/json') ? parseJsonAllowNaN(raw) : raw;
+    const isJson =
+      raw.trim().length > 0 &&
+      (contentType.includes('application/json') || /^[\[{]/.test(raw.trim()));
+    const data = isJson ? parseJsonAllowNaN(raw) : raw;
     if (!res.ok) {
       const msg =
         typeof data === 'object' &&

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -94,6 +94,18 @@ describe('HttpClient', () => {
     expect(res).toEqual({ ok: true });
   });
 
+  it('parses JSON on DELETE even without content-type header', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {}
+      })
+    );
+    const client = new HttpClient({ baseUrl: base, ...creds, fetchImpl: fetchMock });
+    const res = await client.request('DELETE', '/other');
+    expect(res).toEqual({ ok: true });
+  });
+
   it('uses global fetch when none provided', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('pong', {


### PR DESCRIPTION
## Summary
- handle JSON delete responses even when `Content-Type` header is missing
- cover delete JSON parsing

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aabeed45cc8321b87eded2aabe9697