### PR TITLE
fix: retain Content-Type on DELETE requests

### DIFF
--- a/changelog/2025-08-24-0037am-delete-return-representation.md
+++ b/changelog/2025-08-24-0037am-delete-return-representation.md
@@ -1,0 +1,13 @@
+# Change: preserve Content-Type on DELETE requests
+
+- Date: 2025-08-24 12:37 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Retain 'Content-Type: application/json' header on DELETE requests so the API returns the deleted graph.
+  - Update HTTP client tests to reflect header presence.
+- Impact:
+  - Ensures cascade deletes return the deleted entity graph instead of an empty body.
+- Follow-ups:
+  - None

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -63,7 +63,7 @@ export class HttpClient {
       ...(method === 'DELETE' ? { Prefer: 'return=representation' } : {}),
       ...(extraHeaders ?? {}),
     });
-    if (body == null) delete headers['Content-Type'];
+    if (body == null && method !== 'DELETE') delete headers['Content-Type'];
     const init = {
       method,
       headers,

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -87,6 +87,7 @@ describe('HttpClient', () => {
         'x-onyx-key': creds.apiKey,
         'x-onyx-secret': creds.apiSecret,
         Accept: 'application/json',
+        'Content-Type': 'application/json',
         Prefer: 'return=representation'
       },
       body: undefined


### PR DESCRIPTION
## Summary
- keep `Content-Type: application/json` header on DELETE requests so API returns deleted graph
- adjust HTTP client tests
- add changelog entry

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac07722808321b9d52a5a75c25a12