### PR TITLE
test: add ESM and CJS interop tests

### DIFF
--- a/changelog/2025-08-24-1238am-esm-cjs-interop-tests.md
+++ b/changelog/2025-08-24-1238am-esm-cjs-interop-tests.md
@@ -1,0 +1,14 @@
+# Change: add ESM and CJS interop tests
+
+- Date: 2025-08-24 12:38 AM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: test
+- Summary:
+  - add tests confirming CJS and ESM builds share the same named exports
+
+- Impact:
+  - ensures consumers can import the library in both module systems
+
+- Follow-ups:
+  - none

--- a/changelog/2025-08-24-1250am-build-before-interop-tests.md
+++ b/changelog/2025-08-24-1250am-build-before-interop-tests.md
@@ -1,0 +1,14 @@
+# Change: build before running interop tests
+
+- Date: 2025-08-24 12:50 AM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - build the package within interop tests to ensure dist modules exist
+
+- Impact:
+  - `npm test` succeeds without a prior build
+
+- Follow-ups:
+  - none

--- a/codex/tasks/library-readiness/finished/011-esm-cjs-interop-tests.md
+++ b/codex/tasks/library-readiness/finished/011-esm-cjs-interop-tests.md
@@ -8,13 +8,13 @@ Guarantee consumers can import from both module systems.
 2. Add `tests/interop.esm.test.mjs` that dynamic `import()`s ESM build.
 3. Ensure named exports resolution identical in both.
 
-## Plan
+# Plan: Interop tests (ESM & CJS)
 1. Create `tests/interop.cjs.test.cjs` using `require('../dist/index.cjs')`.
 2. Create `tests/interop.esm.test.mjs` with dynamic `import('../dist/index.js')`.
 3. Compare `Object.keys` from each module to verify identical named exports.
 4. Run `npm test` to execute both files under Vitest.
 
 ## Acceptance Criteria
-- [ ] `tests/interop.cjs.test.cjs` requires the CJS build without errors.
-- [ ] `tests/interop.esm.test.mjs` dynamically imports the ESM build without errors.
-- [ ] Named export sets match between ESM and CJS builds.
+- [x] `tests/interop.cjs.test.cjs` requires the CJS build without errors.
+- [x] `tests/interop.esm.test.mjs` dynamically imports the ESM build without errors.
+- [x] Named export sets match between ESM and CJS builds.

--- a/tests/interop.cjs.test.cjs
+++ b/tests/interop.cjs.test.cjs
@@ -1,0 +1,8 @@
+const cjs = require('../dist/index.cjs');
+
+test('CJS build exports match ESM build', async () => {
+  const esm = await import('../dist/index.js');
+  const cjsKeys = Object.keys(cjs).sort();
+  const esmKeys = Object.keys(esm).sort();
+  expect(cjsKeys).toStrictEqual(esmKeys);
+});

--- a/tests/interop.cjs.test.cjs
+++ b/tests/interop.cjs.test.cjs
@@ -1,7 +1,15 @@
-const cjs = require('../dist/index.cjs');
+const { execSync } = require('node:child_process');
 
-test('CJS build exports match ESM build', async () => {
-  const esm = await import('../dist/index.js');
+let cjs;
+let esm;
+
+beforeAll(async () => {
+  execSync('npm run build', { stdio: 'pipe' });
+  cjs = require('../dist/index.cjs');
+  esm = await import('../dist/index.js');
+});
+
+test('CJS build exports match ESM build', () => {
   const cjsKeys = Object.keys(cjs).sort();
   const esmKeys = Object.keys(esm).sort();
   expect(cjsKeys).toStrictEqual(esmKeys);

--- a/tests/interop.esm.test.mjs
+++ b/tests/interop.esm.test.mjs
@@ -1,0 +1,12 @@
+import { createRequire } from 'module';
+import { test, expect } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const cjs = require('../dist/index.cjs');
+const esm = await import('../dist/index.js');
+
+test('ESM build exports match CJS build', () => {
+  const cjsKeys = Object.keys(cjs).sort();
+  const esmKeys = Object.keys(esm).sort();
+  expect(esmKeys).toStrictEqual(cjsKeys);
+});

--- a/tests/interop.esm.test.mjs
+++ b/tests/interop.esm.test.mjs
@@ -1,9 +1,17 @@
 import { createRequire } from 'module';
-import { test, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import { beforeAll, test, expect } from 'vitest';
 
 const require = createRequire(import.meta.url);
-const cjs = require('../dist/index.cjs');
-const esm = await import('../dist/index.js');
+
+let cjs;
+let esm;
+
+beforeAll(async () => {
+  execSync('npm run build', { stdio: 'pipe' });
+  cjs = require('../dist/index.cjs');
+  esm = await import('../dist/index.js');
+});
 
 test('ESM build exports match CJS build', () => {
   const cjsKeys = Object.keys(cjs).sort();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    globals: true,
     coverage: {
       enabled: true,
       provider: 'v8',


### PR DESCRIPTION
## Summary
- add vitest checks ensuring CJS and ESM builds expose the same named exports
- enable global test APIs in vitest
- document interop test task completion

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aac145c75883219b133927548070c5