### PR TITLE
fix: run Debug Example in debug console

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,11 @@
       "runtimeExecutable": "node",
       "runtimeArgs": ["--import=tsx", "--enable-source-maps"],
       "program": "${file}",
-      "console": "integratedTerminal",
+      "console": "internalConsole",
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "sourceMaps": true,
       "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "openOnSessionStart",
       "autoAttachChildProcesses": true
     }
   ]

--- a/changelog/2025-08-24-0040am-debug-console.md
+++ b/changelog/2025-08-24-0040am-debug-console.md
@@ -1,0 +1,12 @@
+# Change: run Debug Example in debug console
+
+- Date: 2025-08-24 12:40 AM PT
+- Author/Agent: ChatGPT
+- Scope: tooling
+- Type: fix
+- Summary:
+  - Configure VS Code Debug Example launch config to use internal debug console.
+- Impact:
+  - Debugging example output appears in VS Code debug console instead of terminal.
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- run VS Code's Debug Example configuration in the internal debug console
- document debug console configuration

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aac1aef7708321857c428a7f2b2bc2