### PR TITLE
fix: avoid double encoding of relationships

### DIFF
--- a/changelog/2025-08-24-0108am-relationship-encoding.md
+++ b/changelog/2025-08-24-0108am-relationship-encoding.md
@@ -1,0 +1,13 @@
+# Change: fix relationship encoding on save/delete
+
+- Date: 2025-08-24 01:08 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Avoid double encoding the `relationships` query parameter for save and delete operations.
+  - Allows delete to return the removed entity when cascading relationships.
+- Impact:
+  - Cascaded save and delete calls now send correct relationship values and receive expected bodies.
+- Follow-ups:
+  - none

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -151,7 +151,7 @@ class OnyxDatabaseImpl<Schema = Record<string, unknown>> implements IOnyxDatabas
     const params = new URLSearchParams();
     if (options?.partition) params.append('partition', options.partition);
     if (options?.relationships?.length) {
-      params.append('relationships', options.relationships.map(encodeURIComponent).join(','));
+      params.append('relationships', options.relationships.join(','));
     }
     const path = `/data/${encodeURIComponent(databaseId)}/${encodeURIComponent(
       table,
@@ -284,7 +284,7 @@ class OnyxDatabaseImpl<Schema = Record<string, unknown>> implements IOnyxDatabas
     const { http, databaseId } = await this.ensureClient();
     const params = new URLSearchParams();
     if (options?.relationships?.length) {
-      params.append('relationships', options.relationships.map(encodeURIComponent).join(','));
+      params.append('relationships', options.relationships.join(','));
     }
     const path = `/data/${encodeURIComponent(databaseId)}/${encodeURIComponent(table)}${
       params.toString() ? `?${params.toString()}` : ''

--- a/tests/relationships-encoding.spec.ts
+++ b/tests/relationships-encoding.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { onyx } from '../src';
+
+// filename: tests/relationships-encoding.spec.ts
+
+describe('relationship encoding', () => {
+  const cfg = {
+    baseUrl: 'https://api.test',
+    databaseId: 'db',
+    apiKey: 'k',
+    apiSecret: 's',
+  };
+
+  it('encodes delete relationships once', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const db = onyx.init({ ...cfg, fetch: fetchMock });
+    await db.delete('Channels', '1', {
+      relationships: ['programs:StreamingProgram(channelId,id)'],
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain(
+      'relationships=programs%3AStreamingProgram%28channelId%2Cid%29'
+    );
+    expect(url).not.toContain('%253A');
+  });
+
+  it('encodes save relationships once', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const db = onyx.init({ ...cfg, fetch: fetchMock });
+    await db.save('Channels', { id: 1 }, {
+      relationships: ['programs:StreamingProgram(channelId,id)'],
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain(
+      'relationships=programs%3AStreamingProgram%28channelId%2Cid%29'
+    );
+    expect(url).not.toContain('%253A');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure save/delete requests send `relationships` without double encoding so deleted entities return
- add tests covering relationship parameter encoding

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aac7d51a3083218eb4aafced52b60b