### PR TITLE
revert: relationship encoding change

### DIFF
--- a/changelog/2025-08-24-0135am-revert-relationship-encoding.md
+++ b/changelog/2025-08-24-0135am-revert-relationship-encoding.md
@@ -1,0 +1,12 @@
+# Change: revert relationship encoding fix
+
+- Date: 2025-08-24 01:35 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Revert relationship encoding change that broke delete responses
+- Impact:
+  - Restores previous delete behavior; relationship paths may be double-encoded
+- Follow-ups:
+  - Investigate proper fix for encoding without breaking delete


### PR DESCRIPTION
## Summary
- revert relationship parameter encoding change that broke delete responses
- remove related regression test and changelog entry
- add changelog entry documenting revert

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aac7d51a3083218eb4aafced52b60b