### PR TITLE
feat(gen): allow extra properties in generated interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const db = onyx.init({
 
 ## Optional: generate TypeScript types from your schema
 
-The package ships a small codegen CLI that emits per-table interfaces, a `tables` enum, and a `Schema` mapping for compile-time safety and IntelliSense.
+The package ships a small codegen CLI that emits per-table interfaces, a `tables` enum, and a `Schema` mapping for compile-time safety and IntelliSense. Each generated interface also includes an index signature so extra properties (for graph attachments in cascade saves) don't trigger type errors.
 
 Generate directly from the API (using the same credential resolver as `init()`):
 

--- a/changelog/2025-08-24-0906am-graph-attachments.md
+++ b/changelog/2025-08-24-0906am-graph-attachments.md
@@ -1,0 +1,13 @@
+# Change: allow graph attachments in generated interfaces
+
+- Date: 2025-08-24 09:06 AM PT
+- Author/Agent: ChatGPT
+- Scope: gen
+- Type: feat
+- Summary:
+  - add index signature to generated table interfaces
+  - enables cascade saves with extra properties without type errors
+- Impact:
+  - generated types accept arbitrary attachments
+- Follow-ups:
+  - none

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,7 +98,7 @@ const db = onyx.init({
 
 ## Optional: generate TypeScript types from your schema
 
-The package ships a small codegen CLI that emits per-table interfaces, a `tables` enum, and a `Schema` mapping for compile-time safety and IntelliSense.
+The package ships a small codegen CLI that emits per-table interfaces, a `tables` enum, and a `Schema` mapping for compile-time safety and IntelliSense. Each generated interface also includes an index signature so extra properties (for graph attachments in cascade saves) don't trigger type errors.
 
 Generate directly from the API (using the same credential resolver as `init()`):
 

--- a/gen/emit.ts
+++ b/gen/emit.ts
@@ -137,6 +137,7 @@ export function emitTypes(schema: OnyxIntrospection, options?: EmitOptions): str
     for (const a of t.attributes) {
       lines.push(propertyLine(a, opts.timestampMode, opts.optionalStrategy));
     }
+    lines.push('  [key: string]: unknown;');
     lines.push('}');
     lines.push('');
   }

--- a/tests/gen-emit.spec.ts
+++ b/tests/gen-emit.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { emitTypes, OnyxIntrospection } from '../gen/emit';
+
+describe('emitTypes', () => {
+  it('allows extra properties for graph attachments', () => {
+    const schema: OnyxIntrospection = {
+      tables: [
+        {
+          name: 'StreamingChannel',
+          attributes: [
+            { name: 'id', type: 'String', isNullable: false },
+          ],
+        },
+      ],
+    };
+    const out = emitTypes(schema);
+    expect(out).toContain('[key: string]: unknown;');
+  });
+});


### PR DESCRIPTION
## Summary
- allow generated table interfaces to accept arbitrary graph attachments via `[key: string]: unknown`
- document index signature behavior for onyx-gen
- add test covering index signature emission

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab37d7b47c8321a6fb45542d3f5071