### PR TITLE
chore: allow manual Codecov workflow run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   changes:
@@ -23,7 +24,7 @@ jobs:
 
   ci:
     needs: changes
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,7 +48,7 @@ jobs:
 
   test:
     needs: changes
-    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.tests == 'true'
+    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.tests == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/changelog/2025-08-24-0927am-manual-codecov-run.md
+++ b/changelog/2025-08-24-0927am-manual-codecov-run.md
@@ -1,0 +1,12 @@
+# Change: allow manual Codecov workflow run
+
+- Date: 2025-08-24 09:27 AM PT
+- Author/Agent: OpenAI Assistant
+- Scope: tooling
+- Type: chore
+- Summary:
+  - permit rerunning CI and Codecov via manual workflow dispatch to refresh coverage badges
+- Impact:
+  - no functional impact; enables manual coverage updates
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- allow CI to be manually dispatched to rerun tests and upload coverage
- document manual Codecov trigger in changelog

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d67335c832187d47a2dc8e11c9e