### PR TITLE
feat: add cascade relationship builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,29 @@ await db.cascade('User.Role').save('User', {
   email: 'dana@example.com',
   Role: ['role_admin', 'role_editor'],
 });
+
+// Cascade relationship syntax:
+// field:Type(target, source)
+//   field  – property on the parent entity
+//   Type   – related table name
+//   target – foreign key on the related table referencing the parent
+//   source – field on the parent entity used as the key
+
+// Using the CascadeRelationshipBuilder
+const programsCascade = db
+  .cascadeBuilder()
+  .graph('programs')
+  .graphType('StreamingProgram')
+  .targetField('channelId')
+  .sourceField('id');
+
+await db.cascade(programsCascade).save('StreamingChannel', {
+  id: 'news_003',
+  category: 'news',
+  name: 'News 24',
+  updatedAt: new Date(),
+  programs: [program], // program defined earlier
+});
 ```
 
 ### 3) Delete (by primary key)

--- a/changelog/2025-08-24-0953am-cascade-relationship-builder.md
+++ b/changelog/2025-08-24-0953am-cascade-relationship-builder.md
@@ -1,0 +1,13 @@
+# Change: add CascadeRelationshipBuilder and cascade docs
+
+- Date: 2025-08-24 09:53 AM PT
+- Author/Agent: openai
+- Scope: lib | docs
+- Type: feat
+- Summary:
+  - Introduced CascadeRelationshipBuilder for composing cascade relationship strings
+  - Documented `field:Type(target, source)` syntax and builder usage
+- Impact:
+  - Adds new public builder method `cascadeBuilder`
+- Follow-ups:
+  - none

--- a/codex/tasks/library-readiness/finished/011-cascade-relationship-builder.md
+++ b/codex/tasks/library-readiness/finished/011-cascade-relationship-builder.md
@@ -1,0 +1,34 @@
+# Task: CascadeRelationshipBuilder and save cascade docs
+
+Original Task:
+```
+save cascade has a specific syntax `field:Type(target, source)`, we need to add documentation for this in the README.  And I would like to create a CascadeRelationshipBuilder that works like this: 
+
+programsCascade = db.cascadeBuilder()
+                                         .graph("programs")
+                                         .graphType("StreamingChannel").targetField('channelId")
+                                         .sourceField("id") // this is the field on StreamingChannel
+
+
+   const newChannel:StreamingChannel = await db     .cascade(programsCascade)     .save(tables.StreamingChannel, {       id: 'news_003',       category: 'news',       name: 'News 24',       updatedAt: new Date(),       programs: [program]   }) as StreamingChannel; 
+
+We need to document this in the README.md along with the save examples
+```
+
+## Plan
+1. Introduce `CascadeRelationshipBuilder` with chainable methods: `graph`, `graphType`, `targetField`, `sourceField` returning the cascade string.
+2. Export a `cascadeBuilder()` method on `IOnyxDatabase` that returns the new builder.
+3. Implement builder in `src/builders/cascade-relationship-builder.ts` and wire into `src/impl/onyx.ts`.
+4. Document cascade syntax `field:Type(target, source)` and builder usage in `README.md`.
+5. Add unit tests covering the builder output.
+6. Regenerate docs and update `docs/README.md`.
+7. Add changelog entry.
+8. Run `npm run typecheck`, `npm test`, and `npm run build`.
+
+## Acceptance Criteria
+- [x] `CascadeRelationshipBuilder` constructs cascade strings like `programs:StreamingProgram(channelId, id)`.
+- [x] `IOnyxDatabase` exposes `cascadeBuilder()`.
+- [x] README documents save cascade syntax and builder usage.
+- [x] Tests cover the builder.
+- [x] Typecheck, build, and tests pass.
+- [x] Changelog entry exists.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,16 @@
 
 # @onyx.dev/onyx-database
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE) [![codecov](https://codecov.io/gh/OnyxDevTools/onyx-database/branch/main/graph/badge.svg)](https://codecov.io/gh/OnyxDevTools/onyx-database)
+
 TypeScript client SDK for **Onyx Cloud Database** — a zero-dependency, strict-typed, builder-pattern API for querying and persisting data in Onyx from Node.js or modern bundlers. Ships ESM & CJS, includes a credential resolver, and an optional **schema code generator** that produces table-safe types and a `tables` enum.
 
 - **Website:** <https://onyx.dev/>
 - **Cloud Console:** <https://cloud.onyx.dev>
 - **Docs hub:** <https://onyx.dev/documentation/>
 - **Cloud API docs:** <https://onyx.dev/documentation/api-documentation/>
-- **API Reference:** [./docs](./docs)
+- **API Reference:** [./docs](_media/docs)
+- **Quality:** 100% unit test coverage enforced in CI
 
 ---
 
@@ -41,7 +44,7 @@ TypeScript client SDK for **Onyx Cloud Database** — a zero-dependency, strict-
 npm i @onyx.dev/onyx-database
 ```
 
-The package is dual-module (ESM + CJS) and has **no runtime dependencies**.
+The package is dual-module (ESM + CJS) and has **no runtime or peer dependencies**.
 
 ---
 
@@ -206,6 +209,29 @@ await db.cascade('User.Role').save('User', {
   email: 'dana@example.com',
   Role: ['role_admin', 'role_editor'],
 });
+
+// Cascade relationship syntax:
+// field:Type(target, source)
+//   field  – property on the parent entity
+//   Type   – related table name
+//   target – foreign key on the related table referencing the parent
+//   source – field on the parent entity used as the key
+
+// Using the CascadeRelationshipBuilder
+const programsCascade = db
+  .cascadeBuilder()
+  .graph('programs')
+  .graphType('StreamingProgram')
+  .targetField('channelId')
+  .sourceField('id');
+
+await db.cascade(programsCascade).save('StreamingChannel', {
+  id: 'news_003',
+  category: 'news',
+  name: 'News 24',
+  updatedAt: new Date(),
+  programs: [program], // program defined earlier
+});
 ```
 
 ### 3) Delete (by primary key)
@@ -214,11 +240,12 @@ await db.cascade('User.Role').save('User', {
 import { onyx } from '@onyx.dev/onyx-database';
 const db = onyx.init();
 
-// Simple delete
-await db.delete('User', 'user_125');
+// Simple delete returns the removed record
+const removed = await db.delete('User', 'user_125');
 
 // Delete cascading relationships (example)
-await db.delete('Role', 'role_temp', { relationships: ['Role.Permission'] });
+const role = await db.delete('Role', 'role_temp', { relationships: ['Role.Permission'] });
+// role includes cascaded relationships
 ```
 
 ### 4) Documents API (binary assets)
@@ -304,6 +331,15 @@ Works in Node 18+ and modern bundlers (Vite, esbuild, Webpack). For TypeScript, 
   }
 }
 ```
+---
+
+## Release workflow
+
+This repository uses [Changesets](https://github.com/changesets/changesets) for versioning and publishing.
+
+1. Run `npm run changeset` to create a changeset entry.
+2. Push to `main` and the **Release** workflow opens a version PR.
+3. Tag the release to trigger `npm run release -- --dry-run` in CI.
 
 ---
 
@@ -316,9 +352,15 @@ Works in Node 18+ and modern bundlers (Vite, esbuild, Webpack). For TypeScript, 
 
 ---
 
+## Security
+
+See [SECURITY.md](_media/SECURITY.md) for our security policy and vulnerability reporting process.
+
+---
+
 ## License
 
-Apache-2.0 © Onyx Dev Tools
+MIT © Onyx Dev Tools. See [LICENSE](_media/LICENSE).
 
 ---
 

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -8,6 +8,7 @@
 
 - [FetchResponse](interfaces/FetchResponse.md)
 - [ICascadeBuilder](interfaces/ICascadeBuilder.md)
+- [ICascadeRelationshipBuilder](interfaces/ICascadeRelationshipBuilder.md)
 - [IConditionBuilder](interfaces/IConditionBuilder.md)
 - [IOnyxDatabase](interfaces/IOnyxDatabase.md)
 - [IQueryBuilder](interfaces/IQueryBuilder.md)

--- a/docs/interfaces/ICascadeBuilder.md
+++ b/docs/interfaces/ICascadeBuilder.md
@@ -36,15 +36,21 @@ Defined in: types/builders.ts:49
 
 ### delete()
 
-> **delete**(`table`, `primaryKey`): `Promise`\<`unknown`\>
+> **delete**\<`Table`\>(`table`, `primaryKey`): `Promise`\<`Schema`\[`Table`\]\>
 
 Defined in: types/builders.ts:54
+
+#### Type Parameters
+
+##### Table
+
+`Table` *extends* `string`
 
 #### Parameters
 
 ##### table
 
-`string`
+`Table`
 
 ##### primaryKey
 
@@ -52,7 +58,7 @@ Defined in: types/builders.ts:54
 
 #### Returns
 
-`Promise`\<`unknown`\>
+`Promise`\<`Schema`\[`Table`\]\>
 
 ***
 

--- a/docs/interfaces/ICascadeRelationshipBuilder.md
+++ b/docs/interfaces/ICascadeRelationshipBuilder.md
@@ -1,0 +1,81 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / ICascadeRelationshipBuilder
+
+# Interface: ICascadeRelationshipBuilder
+
+Defined in: types/builders.ts:59
+
+## Methods
+
+### graph()
+
+> **graph**(`name`): `ICascadeRelationshipBuilder`
+
+Defined in: types/builders.ts:60
+
+#### Parameters
+
+##### name
+
+`string`
+
+#### Returns
+
+`ICascadeRelationshipBuilder`
+
+***
+
+### graphType()
+
+> **graphType**(`type`): `ICascadeRelationshipBuilder`
+
+Defined in: types/builders.ts:61
+
+#### Parameters
+
+##### type
+
+`string`
+
+#### Returns
+
+`ICascadeRelationshipBuilder`
+
+***
+
+### sourceField()
+
+> **sourceField**(`field`): `string`
+
+Defined in: types/builders.ts:63
+
+#### Parameters
+
+##### field
+
+`string`
+
+#### Returns
+
+`string`
+
+***
+
+### targetField()
+
+> **targetField**(`field`): `ICascadeRelationshipBuilder`
+
+Defined in: types/builders.ts:62
+
+#### Parameters
+
+##### field
+
+`string`
+
+#### Returns
+
+`ICascadeRelationshipBuilder`

--- a/docs/interfaces/IOnyxDatabase.md
+++ b/docs/interfaces/IOnyxDatabase.md
@@ -6,7 +6,7 @@
 
 # Interface: IOnyxDatabase\<Schema\>
 
-Defined in: types/public.ts:13
+Defined in: types/public.ts:18
 
 ## Type Parameters
 
@@ -20,7 +20,7 @@ Defined in: types/public.ts:13
 
 > **cascade**(...`relationships`): [`ICascadeBuilder`](ICascadeBuilder.md)\<`Schema`\>
 
-Defined in: types/public.ts:16
+Defined in: types/public.ts:21
 
 #### Parameters
 
@@ -34,11 +34,23 @@ Defined in: types/public.ts:16
 
 ***
 
+### cascadeBuilder()
+
+> **cascadeBuilder**(): [`ICascadeRelationshipBuilder`](ICascadeRelationshipBuilder.md)
+
+Defined in: types/public.ts:22
+
+#### Returns
+
+[`ICascadeRelationshipBuilder`](ICascadeRelationshipBuilder.md)
+
+***
+
 ### close()
 
 > **close**(): `void`
 
-Defined in: types/public.ts:42
+Defined in: types/public.ts:48
 
 Cancels active streams; safe to call multiple times
 
@@ -50,15 +62,25 @@ Cancels active streams; safe to call multiple times
 
 ### delete()
 
-> **delete**(`table`, `primaryKey`, `options?`): `Promise`\<`unknown`\>
+> **delete**\<`Table`, `T`\>(`table`, `primaryKey`, `options?`): `Promise`\<`T`\>
 
-Defined in: types/public.ts:31
+Defined in: types/public.ts:37
+
+#### Type Parameters
+
+##### Table
+
+`Table` *extends* `string`
+
+##### T
+
+`T` = `Schema`\[`Table`\]
 
 #### Parameters
 
 ##### table
 
-`string`
+`Table`
 
 ##### primaryKey
 
@@ -76,7 +98,7 @@ Defined in: types/public.ts:31
 
 #### Returns
 
-`Promise`\<`unknown`\>
+`Promise`\<`T`\>
 
 ***
 
@@ -84,7 +106,7 @@ Defined in: types/public.ts:31
 
 > **deleteDocument**(`documentId`): `Promise`\<`unknown`\>
 
-Defined in: types/public.ts:39
+Defined in: types/public.ts:45
 
 #### Parameters
 
@@ -102,7 +124,7 @@ Defined in: types/public.ts:39
 
 > **findById**\<`Table`, `T`\>(`table`, `primaryKey`, `options?`): `Promise`\<`T`\>
 
-Defined in: types/public.ts:25
+Defined in: types/public.ts:31
 
 #### Type Parameters
 
@@ -144,7 +166,7 @@ Defined in: types/public.ts:25
 
 > **from**\<`Table`\>(`table`): [`IQueryBuilder`](IQueryBuilder.md)\<`Schema`\[`Table`\]\>
 
-Defined in: types/public.ts:14
+Defined in: types/public.ts:19
 
 #### Type Parameters
 
@@ -168,7 +190,7 @@ Defined in: types/public.ts:14
 
 > **getDocument**(`documentId`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: types/public.ts:38
+Defined in: types/public.ts:44
 
 #### Parameters
 
@@ -198,7 +220,7 @@ Defined in: types/public.ts:38
 
 > **save**\<`Table`\>(`table`): [`ISaveBuilder`](ISaveBuilder.md)\<`Schema`\[`Table`\]\>
 
-Defined in: types/public.ts:18
+Defined in: types/public.ts:24
 
 ##### Type Parameters
 
@@ -220,7 +242,7 @@ Defined in: types/public.ts:18
 
 > **save**\<`Table`\>(`table`, `entityOrEntities`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: types/public.ts:19
+Defined in: types/public.ts:25
 
 ##### Type Parameters
 
@@ -254,7 +276,7 @@ Defined in: types/public.ts:19
 
 > **saveDocument**(`doc`): `Promise`\<`unknown`\>
 
-Defined in: types/public.ts:37
+Defined in: types/public.ts:43
 
 #### Parameters
 
@@ -272,7 +294,7 @@ Defined in: types/public.ts:37
 
 > **select**(...`fields`): [`IQueryBuilder`](IQueryBuilder.md)\<`Record`\<`string`, `unknown`\>\>
 
-Defined in: types/public.ts:15
+Defined in: types/public.ts:20
 
 #### Parameters
 

--- a/docs/interfaces/OnyxConfig.md
+++ b/docs/interfaces/OnyxConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: OnyxConfig
 
-Defined in: types/public.ts:5
+Defined in: types/public.ts:10
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: types/public.ts:5
 
 > `optional` **apiKey**: `string`
 
-Defined in: types/public.ts:8
+Defined in: types/public.ts:13
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: types/public.ts:8
 
 > `optional` **apiSecret**: `string`
 
-Defined in: types/public.ts:9
+Defined in: types/public.ts:14
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: types/public.ts:9
 
 > `optional` **baseUrl**: `string`
 
-Defined in: types/public.ts:6
+Defined in: types/public.ts:11
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: types/public.ts:6
 
 > `optional` **databaseId**: `string`
 
-Defined in: types/public.ts:7
+Defined in: types/public.ts:12
 
 ***
 
@@ -46,4 +46,4 @@ Defined in: types/public.ts:7
 
 > `optional` **fetch**: [`FetchImpl`](../type-aliases/FetchImpl.md)
 
-Defined in: types/public.ts:10
+Defined in: types/public.ts:15

--- a/docs/interfaces/OnyxFacade.md
+++ b/docs/interfaces/OnyxFacade.md
@@ -6,7 +6,7 @@
 
 # Interface: OnyxFacade
 
-Defined in: types/public.ts:45
+Defined in: types/public.ts:51
 
 ## Methods
 
@@ -14,7 +14,7 @@ Defined in: types/public.ts:45
 
 > **init**\<`Schema`\>(`config?`): [`IOnyxDatabase`](IOnyxDatabase.md)\<`Schema`\>
 
-Defined in: types/public.ts:46
+Defined in: types/public.ts:52
 
 #### Type Parameters
 

--- a/docs/variables/onyx.md
+++ b/docs/variables/onyx.md
@@ -8,7 +8,7 @@
 
 > `const` **onyx**: [`OnyxFacade`](../interfaces/OnyxFacade.md)
 
-Defined in: impl/onyx.ts:601
+Defined in: impl/onyx.ts:623
 
 -------------------------
 Facade export

--- a/src/builders/cascade-relationship-builder.ts
+++ b/src/builders/cascade-relationship-builder.ts
@@ -1,0 +1,36 @@
+// filename: src/builders/cascade-relationship-builder.ts
+import type { ICascadeRelationshipBuilder } from '../types/builders';
+
+/**
+ * Builder for constructing cascade relationship strings like
+ * `programs:StreamingProgram(channelId, id)`.
+ */
+export class CascadeRelationshipBuilder implements ICascadeRelationshipBuilder {
+  private graphName?: string;
+  private typeName?: string;
+  private target?: string;
+
+  graph(name: string): ICascadeRelationshipBuilder {
+    this.graphName = name;
+    return this;
+  }
+
+  graphType(type: string): ICascadeRelationshipBuilder {
+    this.typeName = type;
+    return this;
+  }
+
+  targetField(field: string): ICascadeRelationshipBuilder {
+    this.target = field;
+    return this;
+  }
+
+  sourceField(field: string): string {
+    if (!this.graphName || !this.typeName || !this.target) {
+      throw new Error('Cascade relationship requires graph, type, target, and source fields');
+    }
+    return `${this.graphName}:${this.typeName}(${this.target}, ${field})`;
+  }
+}
+
+export default CascadeRelationshipBuilder;

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -9,6 +9,7 @@ import type {
   ISaveBuilder,
   ICascadeBuilder,
   IConditionBuilder,
+  ICascadeRelationshipBuilder,
 } from '../types/builders';
 import type {
   QueryCriteria,
@@ -18,6 +19,7 @@ import type {
   QueryPage,
 } from '../types/protocol';
 import type { Sort, StreamAction, OnyxDocument, FetchImpl } from '../types/common';
+import { CascadeRelationshipBuilder } from '../builders/cascade-relationship-builder';
 
 /** -------------------------
  * Internal helpers
@@ -117,6 +119,10 @@ class OnyxDatabaseImpl<Schema = Record<string, unknown>> implements IOnyxDatabas
   cascade(...relationships: string[]): ICascadeBuilder<Schema> {
     const cb = new CascadeBuilderImpl<Schema>(this);
     return cb.cascade(...relationships);
+  }
+
+  cascadeBuilder(): ICascadeRelationshipBuilder {
+    return new CascadeRelationshipBuilder();
   }
 
   // Overload: builder form

--- a/src/types/builders.ts
+++ b/src/types/builders.ts
@@ -56,3 +56,9 @@ export interface ICascadeBuilder<Schema = Record<string, unknown>> {
     primaryKey: string,
   ): Promise<Schema[Table]>;
 }
+export interface ICascadeRelationshipBuilder {
+  graph(name: string): ICascadeRelationshipBuilder;
+  graphType(type: string): ICascadeRelationshipBuilder;
+  targetField(field: string): ICascadeRelationshipBuilder;
+  sourceField(field: string): string;
+}

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -1,6 +1,11 @@
 // filename: src/types/public.ts
 import type { OnyxDocument, FetchImpl } from './common';
-import type { IQueryBuilder, ICascadeBuilder, ISaveBuilder } from './builders';
+import type {
+  IQueryBuilder,
+  ICascadeBuilder,
+  ISaveBuilder,
+  ICascadeRelationshipBuilder,
+} from './builders';
 
 export interface OnyxConfig {
   baseUrl?: string;
@@ -14,6 +19,7 @@ export interface IOnyxDatabase<Schema = Record<string, unknown>> {
   from<Table extends keyof Schema & string>(table: Table): IQueryBuilder<Schema[Table]>;
   select(...fields: string[]): IQueryBuilder<Record<string, unknown>>;
   cascade(...relationships: string[]): ICascadeBuilder<Schema>;
+  cascadeBuilder(): ICascadeRelationshipBuilder;
 
   save<Table extends keyof Schema & string>(table: Table): ISaveBuilder<Schema[Table]>;
   save<Table extends keyof Schema & string>(

--- a/tests/cascade-relationship-builder.spec.ts
+++ b/tests/cascade-relationship-builder.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { CascadeRelationshipBuilder } from '../src/builders/cascade-relationship-builder';
+
+describe('CascadeRelationshipBuilder', () => {
+  it('builds relationship strings', () => {
+    const rel = new CascadeRelationshipBuilder()
+      .graph('programs')
+      .graphType('StreamingProgram')
+      .targetField('channelId')
+      .sourceField('id');
+    expect(rel).toBe('programs:StreamingProgram(channelId, id)');
+  });
+
+  it('throws if fields are missing', () => {
+    const builder = new CascadeRelationshipBuilder();
+    expect(() => builder.sourceField('id')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add CascadeRelationshipBuilder for fluent cascade relation strings
- expose `cascadeBuilder()` on the database API
- document cascade save syntax and builder usage

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run docs`


------
https://chatgpt.com/codex/tasks/task_e_68ab4296795483219046b8894f6ab23a