### PR TITLE
docs: clarify project file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import { onyx } from '@onyx.dev/onyx-database';
 const db = onyx.init(); // resolves from env/project file/home profile
 ```
 
-### Option B) Project file (checked into *your app* repo)
+### Option B) Project file (ignored in *your app* repo)
 
 ```json
 // ./onyx-database.json
@@ -73,6 +73,13 @@ const db = onyx.init(); // resolves from env/project file/home profile
   "apiKey": "YOUR_KEY",
   "apiSecret": "YOUR_SECRET"
 }
+```
+
+This file contains sensitive credentials and **must never be committed** to version control. Add it to `.gitignore`:
+
+```gitignore
+# Onyx project credentials
+onyx-database.json
 ```
 
 ### Option C) Home profile (per-developer)

--- a/changelog/2025-08-24-1103am-project-file-gitignore.md
+++ b/changelog/2025-08-24-1103am-project-file-gitignore.md
@@ -1,0 +1,13 @@
+# Change: clarify project file should be gitignored
+
+- Date: 2025-08-24 11:03 AM PT
+- Author/Agent: openai-dev
+- Scope: docs
+- Type: docs
+- Summary:
+  - clarify that project config files with credentials should not be committed
+  - show .gitignore rule for onyx-database.json
+- Impact:
+  - documentation guidance only
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- note that project config files with credentials must not be committed
- document `.gitignore` rule for `onyx-database.json`

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab53cd933c8321aa3d730bae2f874a