### PR TITLE
fix: stop VSCode debug from hanging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
       "sourceMaps": true,
       "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
       "internalConsoleOptions": "openOnSessionStart",
-      "autoAttachChildProcesses": true
+      "autoAttachChildProcesses": false
     }
   ]
 }

--- a/changelog/2025-08-24-1105am-disable-child-auto-attach.md
+++ b/changelog/2025-08-24-1105am-disable-child-auto-attach.md
@@ -1,0 +1,12 @@
+# Change: disable child process auto-attach in VSCode debug
+
+- Date: 2025-08-24 11:05 AM PT
+- Author/Agent: ChatGPT
+- Scope: tooling
+- Type: fix
+- Summary:
+  - disable autoAttachChildProcesses in launch config to prevent debug sessions from hanging
+- Impact:
+  - improves developer debugging experience; no impact on library runtime
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- disable VSCode's automatic child-process attach to let debug sessions exit cleanly
- document the debugging configuration change

## Testing
- `npm run build`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab53219e44832180a42f9d2aaf4bbd