### PR TITLE
docs: remove NEXT_ env var references

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ This SDK resolves credentials automatically using the chain **environment ➜ pr
 
 ### Option A) Environment variables (recommended for production)
 
-Set any of the following (NEXT_ variants work in frameworks like Next.js):
+Set the following environment variables:
 
-- `ONYX_DATABASE_BASE_URL` or `NEXT_ONYX_DATABASE_BASE_URL`
-- `ONYX_DATABASE_ID` or `NEXT_ONYX_DATABASE_ID`
-- `ONYX_DATABASE_API_KEY` or `NEXT_ONYX_DATABASE_API_KEY`
-- `ONYX_DATABASE_API_SECRET` or `NEXT_ONYX_DATABASE_API_SECRET`
+- `ONYX_DATABASE_BASE_URL`
+- `ONYX_DATABASE_ID`
+- `ONYX_DATABASE_API_KEY`
+- `ONYX_DATABASE_API_SECRET`
 
 ```ts
 import { onyx } from '@onyx.dev/onyx-database';

--- a/changelog/2025-08-24-1107am-remove-next-env-vars.md
+++ b/changelog/2025-08-24-1107am-remove-next-env-vars.md
@@ -1,0 +1,13 @@
+# Change: remove NEXT_* env vars from documentation
+
+- Date: 2025-08-24 11:07 AM PT
+- Author/Agent: ChatGPT
+- Scope: docs
+- Type: docs
+- Summary:
+  - remove references to NEXT_ env vars from README and docs
+  - prevent leaking Onyx credentials via UI-exposed vars
+- Impact:
+  - documentation only
+- Follow-ups:
+  - none

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,12 +54,12 @@ This SDK resolves credentials automatically using the chain **environment ➜ pr
 
 ### Option A) Environment variables (recommended for production)
 
-Set any of the following (NEXT_ variants work in frameworks like Next.js):
+Set the following environment variables:
 
-- `ONYX_DATABASE_BASE_URL` or `NEXT_ONYX_DATABASE_BASE_URL`
-- `ONYX_DATABASE_ID` or `NEXT_ONYX_DATABASE_ID`
-- `ONYX_DATABASE_API_KEY` or `NEXT_ONYX_DATABASE_API_KEY`
-- `ONYX_DATABASE_API_SECRET` or `NEXT_ONYX_DATABASE_API_SECRET`
+- `ONYX_DATABASE_BASE_URL`
+- `ONYX_DATABASE_ID`
+- `ONYX_DATABASE_API_KEY`
+- `ONYX_DATABASE_API_SECRET`
 
 ```ts
 import { onyx } from '@onyx.dev/onyx-database';


### PR DESCRIPTION
## Summary
- remove NEXT_* env var references from README and docs to avoid exposing credentials

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab54a40d608321af91e0f9f49415cc