### PR TITLE
test: align operator enum usage

### DIFF
--- a/changelog/2025-08-24-1124am-test-operator-alias.md
+++ b/changelog/2025-08-24-1124am-test-operator-alias.md
@@ -1,0 +1,13 @@
+# Change: align query operator enum in tests
+
+- Date: 2025-08-24 11:24 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: test
+- Summary:
+  - replace symbolic '=' operators with 'EQUAL' in test criteria
+  - resolves TypeScript warnings about QueryCriteriaOperator
+- Impact:
+  - none
+- Follow-ups:
+  - none

--- a/tests/condition-builder.spec.ts
+++ b/tests/condition-builder.spec.ts
@@ -4,12 +4,12 @@ import { ConditionBuilderImpl } from '../src/builders/condition-builder';
 describe('ConditionBuilderImpl', () => {
   it('builds compound conditions with and/or', () => {
     const cb = new ConditionBuilderImpl();
-    const other = new ConditionBuilderImpl({ field: 'b', operator: '=', value: 2 });
+    const other = new ConditionBuilderImpl({ field: 'b', operator: 'EQUAL', value: 2 });
 
-    cb.and({ field: 'a', operator: '=', value: 1 })
+    cb.and({ field: 'a', operator: 'EQUAL', value: 1 })
       .and(other)
-      .and({ field: 'd', operator: '=', value: 4 })
-      .or({ field: 'c', operator: '=', value: 3 });
+      .and({ field: 'd', operator: 'EQUAL', value: 4 })
+      .or({ field: 'c', operator: 'EQUAL', value: 3 });
 
     expect(cb.toCondition()).toEqual({
       conditionType: 'CompoundCondition',
@@ -19,12 +19,12 @@ describe('ConditionBuilderImpl', () => {
           conditionType: 'CompoundCondition',
           operator: 'AND',
           conditions: [
-            { conditionType: 'SingleCondition', criteria: { field: 'a', operator: '=', value: 1 } },
-            { conditionType: 'SingleCondition', criteria: { field: 'b', operator: '=', value: 2 } },
-            { conditionType: 'SingleCondition', criteria: { field: 'd', operator: '=', value: 4 } }
+            { conditionType: 'SingleCondition', criteria: { field: 'a', operator: 'EQUAL', value: 1 } },
+            { conditionType: 'SingleCondition', criteria: { field: 'b', operator: 'EQUAL', value: 2 } },
+            { conditionType: 'SingleCondition', criteria: { field: 'd', operator: 'EQUAL', value: 4 } }
           ]
         },
-        { conditionType: 'SingleCondition', criteria: { field: 'c', operator: '=', value: 3 } }
+        { conditionType: 'SingleCondition', criteria: { field: 'c', operator: 'EQUAL', value: 3 } }
       ]
     });
   });

--- a/tests/query-builder.spec.ts
+++ b/tests/query-builder.spec.ts
@@ -21,18 +21,18 @@ describe('QueryBuilder', () => {
   it('builds queries and executes operations', async () => {
     const exec = makeExec();
     const qb = new QueryBuilder(exec as any, null);
-    const other = new ConditionBuilderImpl({ field: 'f', operator: '=', value: 6 });
+    const other = new ConditionBuilderImpl({ field: 'f', operator: 'EQUAL', value: 6 });
     qb.from('users')
       .selectFields(['id'])
       .selectFields([])
       .resolve('rel1')
       .resolve(['rel2'])
-      .where({ field: 'a', operator: '=', value: 1 })
-      .where({ field: 'b', operator: '=', value: 2 })
-      .and({ field: 'c', operator: '=', value: 3 })
-      .and({ field: 'd', operator: '=', value: 4 })
+      .where({ field: 'a', operator: 'EQUAL', value: 1 })
+      .where({ field: 'b', operator: 'EQUAL', value: 2 })
+      .and({ field: 'c', operator: 'EQUAL', value: 3 })
+      .and({ field: 'd', operator: 'EQUAL', value: 4 })
       .and(other)
-      .or({ field: 'e', operator: '=', value: 5 })
+      .or({ field: 'e', operator: 'EQUAL', value: 5 })
       .orderBy({ field: 'id', direction: 'asc' })
       .groupBy('role')
       .groupBy()
@@ -57,16 +57,16 @@ describe('QueryBuilder', () => {
   it('covers and/or branches', () => {
     const exec = makeExec();
     const a = new QueryBuilder(exec as any, 't');
-    a.and({ field: 'x', operator: '=', value: 1 });
-    a.and({ field: 'y', operator: '=', value: 2 });
-    a.and({ field: 'z', operator: '=', value: 3 });
+    a.and({ field: 'x', operator: 'EQUAL', value: 1 });
+    a.and({ field: 'y', operator: 'EQUAL', value: 2 });
+    a.and({ field: 'z', operator: 'EQUAL', value: 3 });
 
     const b = new QueryBuilder(exec as any, 't');
-    b.or({ field: 'x', operator: '=', value: 1 });
-    b.or({ field: 'y', operator: '=', value: 2 });
-    b.or({ field: 'z', operator: '=', value: 3 });
+    b.or({ field: 'x', operator: 'EQUAL', value: 1 });
+    b.or({ field: 'y', operator: 'EQUAL', value: 2 });
+    b.or({ field: 'z', operator: 'EQUAL', value: 3 });
     const c = new QueryBuilder(exec as any, 't');
-    c.where({ field: 'x', operator: '=', value: 1 }).or({ field: 'y', operator: '=', value: 2 });
+    c.where({ field: 'x', operator: 'EQUAL', value: 1 }).or({ field: 'y', operator: 'EQUAL', value: 2 });
   });
 
   it('handles defaults and undefined branches', async () => {
@@ -92,13 +92,13 @@ describe('QueryBuilder', () => {
       stream: vi.fn(),
     };
     const qb = new QueryBuilder(exec as any, 'users');
-    qb.where({ field: 'id', operator: '=', value: 1 });
+    qb.where({ field: 'id', operator: 'EQUAL', value: 1 });
     expect(await qb.firstOrNull()).toEqual({ id: 1 });
     expect(exec.queryPage.mock.calls[0][1].limit).toBe(1);
     expect(await qb.firstOrNull()).toBeNull();
 
     const qbAlias = new QueryBuilder(exec as any, 'users');
-    qbAlias.where({ field: 'id', operator: '=', value: 2 });
+    qbAlias.where({ field: 'id', operator: 'EQUAL', value: 2 });
     exec.queryPage.mockResolvedValueOnce({ records: [{ id: 2 }] });
     expect(await qbAlias.one()).toEqual({ id: 2 });
   });
@@ -119,7 +119,7 @@ describe('QueryBuilder', () => {
   it('covers implementation builder firstOrNull', async () => {
     const db = onyx.init({ baseUrl: 'http://x', databaseId: 'd', apiKey: 'k', apiSecret: 's', fetch: vi.fn() as any });
     (db as any)._queryPage = vi.fn().mockResolvedValueOnce({ records: [{ id: 1 }], nextPage: null });
-    const res = await db.from('User').where({ field: 'id', operator: '=', value: 1 }).firstOrNull();
+    const res = await db.from('User').where({ field: 'id', operator: 'EQUAL', value: 1 }).firstOrNull();
     expect(res).toEqual({ id: 1 });
 
     const qb = db.from('User');


### PR DESCRIPTION
## Summary
- ensure tests use `EQUAL` instead of symbolic `=` operator for QueryCriteria

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab58645bcc8321b0e04f9dbbfc2188