### PR TITLE
fix: guard auth headers from overrides

### DIFF
--- a/changelog/2025-08-24-1151am-auth-header-guard.md
+++ b/changelog/2025-08-24-1151am-auth-header-guard.md
@@ -1,0 +1,15 @@
+# Change: prevent overriding auth headers
+
+- Date: 2025-08-24 11:51 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Ignore `x-onyx-key` and `x-onyx-secret` from caller-provided headers.
+  - Test coverage for protected auth headers.
+- Impact:
+  - Prevents accidental credential overrides.
+- Follow-ups:
+  - Task 018: Strict HTTP method typing
+  - Task 019: Validate request URLs
+

--- a/codex/tasks/library-readiness/018-http-method-union.md
+++ b/codex/tasks/library-readiness/018-http-method-union.md
@@ -1,0 +1,10 @@
+# Task 018: Strict HTTP method typing
+
+## Task
+Constrain `HttpClient.request`'s `method` parameter to a union of standard HTTP verbs to improve API design and clarity.
+
+## Acceptance Criteria
+- [ ] `HttpClient.request` accepts only `'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'`
+- [ ] Call sites compile with the stricter type
+- [ ] Tests cover invalid method usage
+

--- a/codex/tasks/library-readiness/019-validate-request-urls.md
+++ b/codex/tasks/library-readiness/019-validate-request-urls.md
@@ -1,0 +1,10 @@
+# Task 019: Validate request URLs
+
+## Task
+Improve stability by validating `baseUrl` and request `path` in `HttpClient` to prevent malformed requests.
+
+## Acceptance Criteria
+- [ ] `HttpClient` constructor throws if `baseUrl` is empty or lacks a protocol
+- [ ] `request` rejects paths that do not start with `/`
+- [ ] Tests verify invalid inputs are handled
+

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -42,13 +42,16 @@ export class HttpClient {
   }
 
   headers(extra?: Record<string, string>): Record<string, string> {
+    const extras = { ...(extra ?? {}) };
+    delete extras['x-onyx-key'];
+    delete extras['x-onyx-secret'];
     return {
       'x-onyx-key': this.apiKey,
       'x-onyx-secret': this.apiSecret,
       'Accept': 'application/json',
       'Content-Type': 'application/json',
       ...this.defaults,
-      ...(extra ?? {})
+      ...extras,
     };
   }
 

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -29,6 +29,22 @@ describe('HttpClient', () => {
     });
   });
 
+  it('does not allow overriding auth headers', () => {
+    const client = new HttpClient({ baseUrl: base, ...creds, fetchImpl: vi.fn() });
+    const headers = client.headers({
+      'x-onyx-key': 'bad',
+      'x-onyx-secret': 'bad',
+      'X-Custom': '1',
+    });
+    expect(headers).toEqual({
+      'x-onyx-key': creds.apiKey,
+      'x-onyx-secret': creds.apiSecret,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Custom': '1',
+    });
+  });
+
   it('uses provided fetch and returns parsed JSON', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {


### PR DESCRIPTION
## Summary
- prevent overriding auth headers in `HttpClient`
- add tests for protected auth headers
- log follow-up tasks for stricter typing and URL validation

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5edbd7208321bbdbacd319fea249