### PR TITLE
docs: add aggregate query example

### DIFF
--- a/changelog/2025-08-24-1225pm-aggregate-query-example.md
+++ b/changelog/2025-08-24-1225pm-aggregate-query-example.md
@@ -1,0 +1,14 @@
+# Change: add aggregate query example
+
+- Date: 2025-08-24 12:25 PM PT
+- Author/Agent: ChatGPT
+- Scope: examples
+- Type: docs
+- Summary:
+  - add example demonstrating count and average rating grouped by stream type
+
+- Impact:
+  - no public API changes
+
+- Follow-ups:
+  - none

--- a/examples/query/aggregate.ts
+++ b/examples/query/aggregate.ts
@@ -1,0 +1,21 @@
+// filename: examples/query/aggregate.ts
+import process from 'node:process';
+import { onyx, count, avg } from '@onyx.dev/onyx-database';
+import { tables, Schema } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const stats = await db
+    .select('streamType', count('*'), avg('rating'))
+    .from(tables.VodItem)
+    .groupBy('streamType')
+    .list();
+
+  console.log(JSON.stringify(stats, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add aggregate query example to demonstrate count and average rating grouped by stream type

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`
- `cd examples && npm run gen:onyx`
- `cd examples && npm start` *(fails: Missing script "start")*
- `cd examples && npm exec tsx query/aggregate.ts` *(fails: Missing required config: databaseId, apiKey, apiSecret)*

------
https://chatgpt.com/codex/tasks/task_e_68ab66b3555c8321a95dc38e346e7ab1