### PR TITLE
fix: allow any index signature in generated types

### DIFF
--- a/changelog/2025-08-24-1239pm-any-index-signature.md
+++ b/changelog/2025-08-24-1239pm-any-index-signature.md
@@ -1,0 +1,13 @@
+# Change: use `any` for generated index signatures
+
+- Date: 2025-08-24 12:39 PM PT
+- Author/Agent: ChatGPT
+- Scope: gen
+- Type: fix
+- Summary:
+  - allow `[key: string]: any` in generated table interfaces
+  - update generator test for new output
+- Impact:
+  - generated interfaces accept arbitrary properties
+- Follow-ups:
+  - none

--- a/gen/emit.ts
+++ b/gen/emit.ts
@@ -137,7 +137,7 @@ export function emitTypes(schema: OnyxIntrospection, options?: EmitOptions): str
     for (const a of t.attributes) {
       lines.push(propertyLine(a, opts.timestampMode, opts.optionalStrategy));
     }
-    lines.push('  [key: string]: unknown;');
+    lines.push('  [key: string]: any;');
     lines.push('}');
     lines.push('');
   }

--- a/tests/gen-emit.spec.ts
+++ b/tests/gen-emit.spec.ts
@@ -14,6 +14,6 @@ describe('emitTypes', () => {
       ],
     };
     const out = emitTypes(schema);
-    expect(out).toContain('[key: string]: unknown;');
+    expect(out).toContain('[key: string]: any;');
   });
 });


### PR DESCRIPTION
## Summary
- emit `[key: string]: any` in generated table interfaces
- adjust codegen test
- record change in changelog

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a1984e0832193d4429ef59006fa