### PR TITLE
fix: emit EmbeddedObject as any

### DIFF
--- a/changelog/2025-08-24-1240pm-embeddedobject-any.md
+++ b/changelog/2025-08-24-1240pm-embeddedobject-any.md
@@ -1,0 +1,13 @@
+# Change: emit EmbeddedObject as any
+
+- Date: 2025-08-24 12:40 PM PT
+- Author/Agent: OpenAI Assistant
+- Scope: cli
+- Type: fix
+- Summary:
+  - Use `any` for EmbeddedObject attributes in generated types.
+- Impact:
+  - Generated types are more permissive; no public API changes.
+- Follow-ups:
+  - none
+

--- a/gen/emit.ts
+++ b/gen/emit.ts
@@ -82,7 +82,7 @@ function tsTypeFor(
     case 'EmbeddedList':
       return 'any[]';
     case 'EmbeddedObject':
-      return 'Record<string, any>';
+      return 'any';
     default:
       return 'any';
   }

--- a/tests/gen-emit.spec.ts
+++ b/tests/gen-emit.spec.ts
@@ -16,4 +16,19 @@ describe('emitTypes', () => {
     const out = emitTypes(schema);
     expect(out).toContain('[key: string]: unknown;');
   });
+
+  it('emits EmbeddedObject attributes as any', () => {
+    const schema: OnyxIntrospection = {
+      tables: [
+        {
+          name: 'Sample',
+          attributes: [
+            { name: 'payload', type: 'EmbeddedObject', isNullable: true },
+          ],
+        },
+      ],
+    };
+    const out = emitTypes(schema);
+    expect(out).toContain('payload: any | null;');
+  });
 });


### PR DESCRIPTION
## Summary
- emit EmbeddedObject attributes as `any`
- add regression test for EmbeddedObject emission
- document change in changelog

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6aa5ab308321b29eb8b2e0e6e36c