### PR TITLE
docs: clarify connection handling in init

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ const db = onyx.init({
 });
 ```
 
+### Connection handling
+
+Calling `onyx.init()` returns a lightweight client. Configuration is resolved once
+and each database instance keeps a single internal `HttpClient`. Requests go
+through Node's built‑in `fetch`, which already reuses connections and pools them
+for keep‑alive. Reuse the returned `db` for multiple operations; extra SDK‑level
+connection pooling generally isn't necessary unless you create many short‑lived
+clients.
+
 ---
 
 ## Optional: generate TypeScript types from your schema

--- a/changelog/2025-08-24-1244pm-connection-pooling-docs.md
+++ b/changelog/2025-08-24-1244pm-connection-pooling-docs.md
@@ -1,0 +1,16 @@
+# Change: document connection handling in init()
+
+- Date: 2025-08-24 12:44 PM PT
+- Author/Agent: ChatGPT
+- Scope: docs
+- Type: docs
+- Summary:
+  - explain that `onyx.init()` creates a lightweight client with an internal HttpClient
+  - note that Node's `fetch` already provides keep-alive and connection pooling
+
+- Impact:
+  - clarifies connection reuse; no API changes
+
+- Follow-ups:
+  - none
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,15 @@ const db = onyx.init({
 });
 ```
 
+### Connection handling
+
+Calling `onyx.init()` returns a lightweight client. Configuration is resolved once
+and each database instance keeps a single internal `HttpClient`. Requests go
+through Node's built‑in `fetch`, which already reuses connections and pools them
+for keep‑alive. Reuse the returned `db` for multiple operations; extra SDK‑level
+connection pooling generally isn't necessary unless you create many short‑lived
+clients.
+
 ---
 
 ## Optional: generate TypeScript types from your schema

--- a/docs/interfaces/OnyxFacade.md
+++ b/docs/interfaces/OnyxFacade.md
@@ -31,3 +31,9 @@ Defined in: types/public.ts:52
 #### Returns
 
 [`IOnyxDatabase`](IOnyxDatabase.md)\<`Schema`\>
+
+#### Remarks
+
+Each returned client resolves configuration once and maintains a single internal
+HTTP handler. Requests use Node's `fetch`, which keeps connections alive and
+pools them, so extra connection caching is rarely required.

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -227,9 +227,9 @@ export interface IOnyxDatabase<Schema = Record<string, unknown>> {
 
 export interface OnyxFacade {
   /**
-   * Initialize a database client.
-   *
-   * @example
+  * Initialize a database client.
+  *
+  * @example
    * ```ts
    * const db = onyx.init({
    *   baseUrl: 'https://api.onyx.dev',
@@ -237,10 +237,15 @@ export interface OnyxFacade {
    *   apiKey: 'key',
    *   apiSecret: 'secret'
    * });
-   * ```
-   *
-   * @param config Connection settings and optional custom fetch.
-   */
+  * ```
+  *
+  * @param config Connection settings and optional custom fetch.
+   * @remarks
+   * Each `db` instance resolves configuration once and holds a single internal
+   * HTTP client. Requests leverage Node's built-in `fetch`, which reuses and
+   * pools connections for keep-alive, so additional connection caching or
+   * pooling is rarely necessary.
+  */
   init<Schema = Record<string, unknown>>(config?: OnyxConfig): IOnyxDatabase<Schema>;
 }
 


### PR DESCRIPTION
## Summary
- clarify that `onyx.init()` creates a lightweight client and reuses connections via Node's `fetch`
- add remarks about connection pooling to the API docs

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6898290c8321b9d29ec19e4053e4