### PR TITLE
refactor: require config object for init

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The package is dual-module (ESM + CJS) and has **no runtime or peer dependencies
 
 ## Initialize the client
 
-This SDK resolves credentials automatically using the chain **environment ➜ project file ➜ home profile** (highest to lowest precedence). Call `onyx.init('database-id')` to target a specific database, or omit the ID to use the default. You can also pass credentials directly via config.
+This SDK resolves credentials automatically using the chain **environment ➜ project file ➜ home profile** (highest to lowest precedence). Call `onyx.init({ databaseId: 'database-id' })` to target a specific database, or omit the `databaseId` to use the default. You can also pass credentials directly via config.
 
 ### Option A) Environment variables (recommended for production)
 
@@ -60,7 +60,7 @@ Set the following environment variables for your database:
 ```ts
 import { onyx } from '@onyx.dev/onyx-database';
 
-const db = onyx.init('YOUR_DATABASE_ID'); // uses env when ID matches
+const db = onyx.init({ databaseId: 'YOUR_DATABASE_ID' }); // uses env when ID matches
 ```
 
 ### Option B) Project file (ignored in *your app* repo)

--- a/changelog/2025-08-24-0100pm-init-config-object.md
+++ b/changelog/2025-08-24-0100pm-init-config-object.md
@@ -1,0 +1,13 @@
+# Change: require config object for init
+
+- Date: 2025-08-24 01:00 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib | docs
+- Type: refactor
+- Summary:
+  - enforce `onyx.init` to accept only `OnyxConfig`
+  - update documentation examples to pass `{ databaseId }`
+- Impact:
+  - public API change; raw database ID strings are no longer accepted
+- Follow-ups:
+  - none

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ The package is dual-module (ESM + CJS) and has **no runtime or peer dependencies
 
 ## Initialize the client
 
-This SDK resolves credentials automatically using the chain **environment ➜ project file ➜ home profile** (highest to lowest precedence). Call `onyx.init('database-id')` to target a specific database, or omit the ID to use the default. You can also pass credentials directly via config.
+This SDK resolves credentials automatically using the chain **environment ➜ project file ➜ home profile** (highest to lowest precedence). Call `onyx.init({ databaseId: 'database-id' })` to target a specific database, or omit the `databaseId` to use the default. You can also pass credentials directly via config.
 
 ### Option A) Environment variables (recommended for production)
 
@@ -64,7 +64,7 @@ Set the following environment variables for your database:
 ```ts
 import { onyx } from '@onyx.dev/onyx-database';
 
-const db = onyx.init('YOUR_DATABASE_ID'); // uses env when ID matches
+const db = onyx.init({ databaseId: 'YOUR_DATABASE_ID' }); // uses env when ID matches
 ```
 
 ### Option B) Project file (checked into *your app* repo)

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -634,11 +634,7 @@ class CascadeBuilderImpl<Schema = Record<string, unknown>>
  * Facade export
  * --------------------------*/
 export const onyx: OnyxFacade = {
-  init<Schema = Record<string, unknown>>(dbOrConfig?: string | OnyxConfig, config?: OnyxConfig): IOnyxDatabase<Schema> {
-    const cfg: OnyxConfig | undefined =
-      typeof dbOrConfig === 'string'
-        ? { ...config, databaseId: dbOrConfig }
-        : dbOrConfig;
-    return new OnyxDatabaseImpl<Schema>(cfg);
+  init<Schema = Record<string, unknown>>(config?: OnyxConfig): IOnyxDatabase<Schema> {
+    return new OnyxDatabaseImpl<Schema>(config);
   },
 };

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -243,13 +243,10 @@ export interface OnyxFacade {
    * @remarks
    * Each `db` instance resolves configuration once and holds a single internal
    * HTTP client. Requests leverage Node's built-in `fetch`, which reuses and
-   * pools connections for keep-alive, so additional connection caching or
-   * pooling is rarely necessary.
+  * pools connections for keep-alive, so additional connection caching or
+  * pooling is rarely necessary.
   */
-  init<Schema = Record<string, unknown>>(
-    dbOrConfig?: string | OnyxConfig,
-    config?: OnyxConfig,
-  ): IOnyxDatabase<Schema>;
+  init<Schema = Record<string, unknown>>(config?: OnyxConfig): IOnyxDatabase<Schema>;
 }
 
 export * from './common';


### PR DESCRIPTION
## Summary
- simplify `onyx.init` to accept only an `OnyxConfig` object
- update README and docs for new initialization pattern
- record change in changelog

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6ec90ae88321a1793a03c2934c47