### PR TITLE
test: skip smoke test without config

### DIFF
--- a/changelog/2025-08-24-0115pm-skip-smoke-on-missing-config.md
+++ b/changelog/2025-08-24-0115pm-skip-smoke-on-missing-config.md
@@ -1,0 +1,12 @@
+# Change: skip smoke test without config
+
+- Date: 2025-08-24 01:15 PM PT
+- Author/Agent: openai-assistant
+- Scope: test
+- Type: fix
+- Summary:
+  - skip integration smoke test when required Onyx configuration is missing
+- Impact:
+  - avoids false failures in environments lacking credentials
+- Follow-ups:
+  - none

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { onyx, eq, contains, startsWith, gt } from '../src';
+import { resolveConfig } from '../src/config/chain';
 
+let hasConfig = true;
+try {
+  await resolveConfig();
+} catch {
+  hasConfig = false;
+}
 
-describe('smoke e2e', () => {
-    it('creates, queries, and deletes a channel', async () => {
+describe.runIf(hasConfig)('smoke e2e', () => {
+  it('creates, queries, and deletes a channel', async () => {
     const db = onyx.init();
 
     const program = {


### PR DESCRIPTION
## Summary
- skip integration smoke test when required Onyx configuration is missing

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run test:smoke` (skipped)


------
https://chatgpt.com/codex/tasks/task_e_68ab70d57a40832181e26d2799a7bb3a