### PR TITLE
feat: cache resolved config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Set the following environment variables for your database:
 import { onyx } from '@onyx.dev/onyx-database';
 
 const db = onyx.init({ databaseId: 'YOUR_DATABASE_ID' }); // uses env when ID matches
+// credentials are cached for 5 minutes by default
 ```
 
 ### Option B) Project file (ignored in *your app* repo)
@@ -103,11 +104,12 @@ const db = onyx.init({
 ### Connection handling
 
 Calling `onyx.init()` returns a lightweight client. Configuration is resolved once
-and each database instance keeps a single internal `HttpClient`. Requests go
-through Node's built‑in `fetch`, which already reuses connections and pools them
-for keep‑alive. Reuse the returned `db` for multiple operations; extra SDK‑level
-connection pooling generally isn't necessary unless you create many short‑lived
-clients.
+and cached for 5 minutes to avoid repeated credential lookups (override with
+`ttl` or reset via `onyx.clearCacheConfig()`). Each database instance keeps a
+single internal `HttpClient`. Requests go through Node's built‑in `fetch`, which
+already reuses connections and pools them for keep‑alive. Reuse the returned
+`db` for multiple operations; extra SDK‑level connection pooling generally isn't
+necessary unless you create many short‑lived clients.
 
 ---
 

--- a/changelog/2025-08-24-0134pm-config-cache.md
+++ b/changelog/2025-08-24-0134pm-config-cache.md
@@ -1,0 +1,14 @@
+# Change: cache config with TTL
+
+- Date: 2025-08-24 01:34 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: feat
+- Summary:
+  - cache resolved credentials with a default 5 minute TTL
+  - expose onyx.clearCacheConfig to reset the cache
+  - document TTL option and caching behavior
+- Impact:
+  - public API added: OnyxConfig.ttl and onyx.clearCacheConfig
+- Follow-ups:
+  - none

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -13,6 +13,10 @@ export interface OnyxConfig {
   apiKey?: string;
   apiSecret?: string;
   fetch?: FetchImpl;
+  /**
+   * Milliseconds to cache resolved credentials; defaults to 5 minutes.
+   */
+  ttl?: number;
 }
 
 export interface IOnyxDatabase<Schema = Record<string, unknown>> {
@@ -247,6 +251,12 @@ export interface OnyxFacade {
   * pooling is rarely necessary.
   */
   init<Schema = Record<string, unknown>>(config?: OnyxConfig): IOnyxDatabase<Schema>;
+
+  /**
+   * Clear cached configuration so the next {@link init} call re-resolves
+   * credentials immediately.
+   */
+  clearCacheConfig(): void;
 }
 
 export * from './common';

--- a/tests/config-cache.spec.ts
+++ b/tests/config-cache.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { onyx } from '../src';
+import * as chain from '../src/config/chain';
+
+const origEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...origEnv };
+  onyx.clearCacheConfig();
+  vi.useRealTimers();
+});
+
+describe('config cache', () => {
+  it('reuses resolved config within ttl', () => {
+    const spy = vi.spyOn(chain, 'resolveConfig');
+    process.env.ONYX_DATABASE_ID = 'id';
+    process.env.ONYX_DATABASE_API_KEY = 'k';
+    process.env.ONYX_DATABASE_API_SECRET = 's';
+    process.env.ONYX_DATABASE_BASE_URL = 'http://env';
+
+    onyx.init();
+    onyx.init();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires cache after ttl', () => {
+    vi.useFakeTimers();
+    const spy = vi.spyOn(chain, 'resolveConfig');
+    process.env.ONYX_DATABASE_ID = 'id';
+    process.env.ONYX_DATABASE_API_KEY = 'k';
+    process.env.ONYX_DATABASE_API_SECRET = 's';
+    process.env.ONYX_DATABASE_BASE_URL = 'http://env';
+
+    onyx.init({ ttl: 100 });
+    onyx.init({ ttl: 100 });
+    expect(spy).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(101);
+    onyx.init({ ttl: 100 });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearCacheConfig forces re-resolve', () => {
+    const spy = vi.spyOn(chain, 'resolveConfig');
+    process.env.ONYX_DATABASE_ID = 'id';
+    process.env.ONYX_DATABASE_API_KEY = 'k';
+    process.env.ONYX_DATABASE_API_SECRET = 's';
+    process.env.ONYX_DATABASE_BASE_URL = 'http://env';
+
+    onyx.init();
+    onyx.clearCacheConfig();
+    onyx.init();
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- cache resolved config with a default 5 minute TTL
- expose `onyx.clearCacheConfig()` to reset the cache
- document caching behaviour and add tests

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab76fcc7e8832188cc2c160f125174