### PR TITLE
fix: resolve lint warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,7 @@ If adjusting codegen behavior, keep CLI flags backward‑compatible and update R
 
 ## Quality Checklist (pre‑PR)
 
+- [ ] **Lint clean**: `npm run lint` and fix warnings/errors
 - [ ] **Types compile**: `npm run typecheck`
 - [ ] **Build passes**: `npm run build`
 - [ ] **No runtime deps added**

--- a/changelog/2025-08-24-0210pm-lint-fixes.md
+++ b/changelog/2025-08-24-0210pm-lint-fixes.md
@@ -1,0 +1,14 @@
+# Change: fix lint warnings in examples and cache
+
+- Date: 2025-08-24 02:10 PM PT
+- Author/Agent: ChatGPT
+- Scope: examples | lib | docs
+- Type: fix
+- Summary:
+  - remove unused aggregate helpers in example queries
+  - discard unused ttl option in cached config resolution
+  - require running lint before commits in AGENTS guide
+- Impact:
+  - no runtime behavior change
+- Follow-ups:
+  - none

--- a/examples/query/aggregate-sum.ts
+++ b/examples/query/aggregate-sum.ts
@@ -1,6 +1,6 @@
 // filename: examples/query/aggregate.ts
 import process from 'node:process';
-import { onyx, count, avg, sum } from '@onyx.dev/onyx-database';
+import { onyx, sum } from '@onyx.dev/onyx-database';
 import { tables, Schema } from 'onyx/types';
 
 async function main(): Promise<void> {

--- a/examples/query/aggregates-with-grouping.ts
+++ b/examples/query/aggregates-with-grouping.ts
@@ -1,6 +1,6 @@
 // filename: examples/query/aggregate.ts
 import process from 'node:process';
-import { onyx, count, avg } from '@onyx.dev/onyx-database';
+import { onyx, avg } from '@onyx.dev/onyx-database';
 import { tables, Schema } from 'onyx/types';
 
 async function main(): Promise<void> {

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -33,6 +33,7 @@ function resolveConfigWithCache(config?: OnyxConfig): Promise<ResolvedConfig> {
     return cachedCfg.promise;
   }
   const { ttl: _ttl, ...rest } = config ?? {};
+  void _ttl;
   const promise = resolveConfig(rest);
   cachedCfg = { promise, expires: now + ttl };
   return promise;


### PR DESCRIPTION
## Summary
- remove unused aggregate helpers in example queries
- discard unused ttl option in cached config resolution
- document lint requirement in agents guide

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run gen:onyx` (examples)
- `npm start` (examples) *(fails: Missing script: "start")*


------
https://chatgpt.com/codex/tasks/task_e_68ab7f7c4c908321bec38c8abfb2033e