### PR TITLE
fix: load home profile when env lacks id

### DIFF
--- a/changelog/2025-08-24-1255pm-home-profile-env.md
+++ b/changelog/2025-08-24-1255pm-home-profile-env.md
@@ -1,0 +1,13 @@
+# Change: allow home profile when env missing id
+
+- Date: 2025-08-24 12:55 PM PT
+- Author/Agent: openai
+- Scope: lib
+- Type: fix
+- Summary:
+  - read project/home config when env lacks database id
+  - pass env database id to file lookups
+- Impact:
+  - ensures ~/.onyx/onyx-database.json is used when only API credentials are in env
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- ensure config chain reads project/home files when env missing database id
- allow env api credentials without database id
- add regression test for env+home profile

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run test:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68abab30609483218efe1e04e8f6208a