### PR TITLE
refactor: drop NEXT_* env var support

### DIFF
--- a/changelog/2025-08-24-0531pm-remove-next-env-support.md
+++ b/changelog/2025-08-24-0531pm-remove-next-env-support.md
@@ -1,0 +1,13 @@
+# Change: remove NEXT_* env var support
+
+- Date: 2025-08-24 05:31 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: refactor
+- Summary:
+  - drop support for NEXT_* environment variables in config chain
+  - ensure credentials are sourced only from server-side env vars
+- Impact:
+  - NEXT_* env vars are no longer recognized
+- Follow-ups:
+  - none

--- a/src/config/chain.ts
+++ b/src/config/chain.ts
@@ -42,13 +42,13 @@ function readEnv(targetId?: string): Partial<OnyxConfig> {
     return undefined;
   };
 
-  const envId = pick('ONYX_DATABASE_ID', 'NEXT_ONYX_DATABASE_ID');
+  const envId = pick('ONYX_DATABASE_ID');
   if (targetId && envId && targetId !== envId) return {};
   const res = dropUndefined<OnyxConfig>({
-    baseUrl: pick('ONYX_DATABASE_BASE_URL', 'NEXT_ONYX_DATABASE_BASE_URL'),
+    baseUrl: pick('ONYX_DATABASE_BASE_URL'),
     databaseId: targetId ?? envId,
-    apiKey: pick('ONYX_DATABASE_API_KEY', 'NEXT_ONYX_DATABASE_API_KEY'),
-    apiSecret: pick('ONYX_DATABASE_API_SECRET', 'NEXT_ONYX_DATABASE_API_SECRET'),
+    apiKey: pick('ONYX_DATABASE_API_KEY'),
+    apiSecret: pick('ONYX_DATABASE_API_SECRET'),
   });
   if (Object.keys(res).length === 0) return {};
   dbg('env:', mask(res));

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { resolveConfig } from '../src/config/chain';
+import { OnyxConfigError } from '../src/errors/config-error';
 import { mkdtemp, writeFile, mkdir, unlink } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir, homedir } from 'node:os';
@@ -24,6 +25,14 @@ describe('config chain database selection', () => {
     expect(cfg.baseUrl).toBe('http://env');
     expect(cfg.apiKey).toBe('k');
     expect(cfg.apiSecret).toBe('s');
+  });
+
+  it('ignores NEXT_* env vars', async () => {
+    process.env.NEXT_ONYX_DATABASE_ID = 'nid';
+    process.env.NEXT_ONYX_DATABASE_BASE_URL = 'http://next';
+    process.env.NEXT_ONYX_DATABASE_API_KEY = 'nk';
+    process.env.NEXT_ONYX_DATABASE_API_SECRET = 'ns';
+    await expect(resolveConfig({ databaseId: 'nid' })).rejects.toBeInstanceOf(OnyxConfigError);
   });
 
   it('prefers project file over home profile when env id differs', async () => {


### PR DESCRIPTION
## Summary
- remove NEXT_* environment variable fallbacks from config chain
- add regression test ensuring NEXT_* env vars are ignored
- document removal of NEXT_* env var support

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abae8eedb883219040ac241bc7b252