### PR TITLE
chore: verify tests before version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
+      - run: npm test
+      - run: npm run test:smoke
       - uses: changesets/action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog/2025-08-24-0537pm-release-tests.md
+++ b/changelog/2025-08-24-0537pm-release-tests.md
@@ -1,0 +1,12 @@
+# Change: verify tests before version cut
+
+- Date: 2025-08-24 05:37 PM PT
+- Author/Agent: ChatGPT
+- Scope: tooling
+- Type: chore
+- Summary:
+  - add unit and smoke test checks to the version job in the release workflow
+- Impact:
+  - ensures version bumps only occur when tests pass
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- run unit and smoke tests in release workflow before version bumps

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run test:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68abb0103178832180bc905d7055b40a