### PR TITLE
docs: add stream example

### DIFF
--- a/changelog/2025-08-24-1104pm-stream-example.md
+++ b/changelog/2025-08-24-1104pm-stream-example.md
@@ -1,0 +1,12 @@
+# Change: add stream example
+
+- Date: 2025-08-24 11:04 PM PT
+- Author/Agent: assistant
+- Scope: examples
+- Type: docs
+- Summary:
+  - add example showing add/update/delete streaming lifecycle with auto cancellation
+- Impact:
+  - no runtime impact; documentation only
+- Follow-ups:
+  - none

--- a/examples/stream/basic.ts
+++ b/examples/stream/basic.ts
@@ -1,0 +1,58 @@
+// filename: examples/stream/basic.ts
+import process from 'node:process';
+import { onyx, eq } from '@onyx.dev/onyx-database';
+import { tables, Schema } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const events: Array<'added' | 'updated' | 'deleted'> = [];
+  let handle: { cancel(): void } | null = null;
+  const maybeCancel = (): void => {
+    if (events.join(',') === 'added,updated,deleted') {
+      handle?.cancel();
+    }
+  };
+
+  const stream = db
+    .from(tables.StreamingChannel)
+    .where(eq('category', 'news'))
+    .onItemAdded((item) => {
+      console.log('ITEM ADDED', item);
+      events.push('added');
+      maybeCancel();
+    })
+    .onItemUpdated((item) => {
+      console.log('ITEM UPDATED', item);
+      events.push('updated');
+      maybeCancel();
+    })
+    .onItemDeleted((item) => {
+      console.log('ITEM DELETED', item);
+      events.push('deleted');
+      maybeCancel();
+    });
+
+  handle = await stream.stream(true, false);
+
+  await db.save(tables.StreamingChannel, {
+    id: 'news_001',
+    category: 'news',
+    name: 'News 24',
+    updatedAt: new Date(),
+  });
+
+  await db.save(tables.StreamingChannel, {
+    id: 'news_001',
+    category: 'news',
+    name: 'News 24 - Updated',
+    updatedAt: new Date(),
+  });
+
+  await db.delete(tables.StreamingChannel, 'news_001');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add streaming usage example

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `cd examples && npm run gen:onyx`
- `cd examples && npm start` *(fails: Missing script "start")*


------
https://chatgpt.com/codex/tasks/task_e_68abfc7ea65c8321abb01a709a66b521