### PR TITLE
fix stream example hang and logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "runtimeExecutable": "node",
       "runtimeArgs": ["--import=tsx", "--enable-source-maps"],
       "program": "${file}",
-      "console": "internalConsole",
+      "console": "integratedTerminal",
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "sourceMaps": true,
       "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],

--- a/changelog/2025-08-24-1153pm-fix-stream-example.md
+++ b/changelog/2025-08-24-1153pm-fix-stream-example.md
@@ -1,0 +1,14 @@
+# Change: fix stream example logging and exit
+
+- Date: 2025-08-24 11:53 PM PT
+- Author/Agent: OpenAI ChatGPT
+- Scope: examples
+- Type: fix
+- Summary:
+  - add auto-cancel timeout and event logging to stream example
+  - direct VS Code launch config output to integrated terminal
+- Impact:
+  - stream example no longer hangs when events don't arrive and logs actions
+- Follow-ups:
+  - none
+

--- a/examples/stream/basic.ts
+++ b/examples/stream/basic.ts
@@ -31,9 +31,16 @@ async function main(): Promise<void> {
       console.log('ITEM DELETED', item);
       events.push('deleted');
       maybeCancel();
+    })
+    .onItem((entity, action) => {
+      console.log('STREAM EVENT', action, entity);
     });
 
   handle = await stream.stream(true, false);
+  setTimeout(() => {
+    console.log('Stream timed out, cancelling');
+    handle?.cancel();
+  }, 5_000);
 
   await db.save(tables.StreamingChannel, {
     id: 'news_001',


### PR DESCRIPTION
## Summary
- log stream events and add timeout to cancel after 5s in stream example
- show stream output in VS Code integrated terminal

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm --prefix examples run gen:onyx`
- `node --import=tsx stream/basic.ts` *(fails: OnyxConfigError: Missing required config)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0820cc448321918f6b6efc78db09