### PR TITLE
fix stream example cancellation

### DIFF
--- a/changelog/2025-08-25-stream-example-cancel.md
+++ b/changelog/2025-08-25-stream-example-cancel.md
@@ -1,0 +1,13 @@
+# Change: fix stream example cancellation
+
+- Date: 2025-08-25 12:15 AM PT
+- Author/Agent: ChatGPT
+- Scope: examples
+- Type: fix
+- Summary:
+  - prevent stream example from hanging by clearing timeout on cancel
+  - log stream lifecycle events
+- Impact:
+  - developer documentation only
+- Follow-ups:
+  - none

--- a/examples/stream/basic.ts
+++ b/examples/stream/basic.ts
@@ -8,9 +8,18 @@ async function main(): Promise<void> {
 
   const events: Array<'added' | 'updated' | 'deleted'> = [];
   let handle: { cancel(): void } | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const cancel = (): void => {
+    handle?.cancel();
+    if (timer) clearTimeout(timer);
+    console.log('Stream cancelled');
+  };
+
   const maybeCancel = (): void => {
     if (events.join(',') === 'added,updated,deleted') {
-      handle?.cancel();
+      console.log('All events received');
+      cancel();
     }
   };
 
@@ -37,9 +46,10 @@ async function main(): Promise<void> {
     });
 
   handle = await stream.stream(true, false);
-  setTimeout(() => {
+  console.log('Stream started');
+  timer = setTimeout(() => {
     console.log('Stream timed out, cancelling');
-    handle?.cancel();
+    cancel();
   }, 5_000);
 
   await db.save(tables.StreamingChannel, {


### PR DESCRIPTION
## Summary
- avoid hanging in basic stream example by clearing timeout on cancel
- log stream lifecycle events for easier debugging

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `cd examples && npm run gen:onyx`
- `cd examples && node --import=tsx stream/basic.ts` *(fails: OnyxConfigError: Missing required config)*


------
https://chatgpt.com/codex/tasks/task_e_68ac0d3816e88321bd643ba65a571637