### PR TITLE
fix: keep streaming examples alive for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,8 +366,8 @@ const stream = db
   .onItemDeleted((u) => console.log('USER DELETED', u))
   .onItem((entity, action) => console.log('STREAM EVENT', action, entity));
 
-// Start the stream; include query results and keep-alive as desired:
-const handle = await stream.stream(true, false);
+// Start the stream and keep the connection alive for new events:
+const handle = await stream.stream(true, true);
 
 // Later, cancel:
 setTimeout(() => handle.cancel(), 60_000);

--- a/changelog/2025-08-25-1232am-stream-keepalive.md
+++ b/changelog/2025-08-25-1232am-stream-keepalive.md
@@ -1,0 +1,12 @@
+# Change: keep streaming examples alive for events
+
+- Date: 2025-08-25 12:32 AM PT
+- Author/Agent: OpenAI ChatGPT
+- Scope: examples | docs
+- Type: fix
+- Summary:
+  - Ensure streaming samples use `keepAlive` to receive subsequent database events.
+- Impact:
+  - Examples and documentation now correctly demonstrate live updates.
+- Follow-ups:
+  - None

--- a/docs/README.md
+++ b/docs/README.md
@@ -371,8 +371,8 @@ const stream = db
   .onItemDeleted((u) => console.log('USER DELETED', u))
   .onItem((entity, action) => console.log('STREAM EVENT', action, entity));
 
-// Start the stream; include query results and keep-alive as desired:
-const handle = await stream.stream(true, false);
+// Start the stream and keep the connection alive for new events:
+const handle = await stream.stream(true, true);
 
 // Later, cancel:
 setTimeout(() => handle.cancel(), 60_000);

--- a/examples/stream/basic.ts
+++ b/examples/stream/basic.ts
@@ -45,7 +45,8 @@ async function main(): Promise<void> {
       console.log('STREAM EVENT', action, entity);
     });
 
-  handle = await stream.stream(true, false);
+  // keep the connection alive so subsequent saves trigger events
+  handle = await stream.stream(true, true);
   console.log('Stream started');
   timer = setTimeout(() => {
     console.log('Stream timed out, cancelling');


### PR DESCRIPTION
## Summary
- ensure streaming example calls `keepAlive` so events propagate
- clarify in docs that stream must keep connection alive for updates
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run gen:onyx` (examples)
- `node --import=tsx stream/basic.ts` *(fails: Missing required config: databaseId, apiKey, apiSecret)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1139d9a88321a992852587398867