### PR TITLE
fix: prevent stream example from hanging

### DIFF
--- a/changelog/2025-08-25-0117am-stream-example-hang.md
+++ b/changelog/2025-08-25-0117am-stream-example-hang.md
@@ -1,0 +1,12 @@
+# Change: prevent stream example from hanging
+
+- Date: 2025-08-25 01:17 AM PT
+- Author/Agent: ChatGPT
+- Scope: examples
+- Type: fix
+- Summary:
+  - start stream without awaiting to allow writes to run concurrently
+- Impact:
+  - ensures stream example emits events immediately
+- Follow-ups:
+  - none

--- a/examples/stream/basic.ts
+++ b/examples/stream/basic.ts
@@ -46,8 +46,17 @@ async function main(): Promise<void> {
     });
 
   // keep the connection alive so subsequent saves trigger events
-  handle = await stream.stream(true, true);
-  console.log('Stream started');
+  void stream
+    .stream(true, true)
+    .then((h) => {
+      handle = h;
+      console.log('Stream started');
+    })
+    .catch((err) => {
+      console.error('Stream failed', err);
+      cancel();
+    });
+
   // allow the subscription to fully register before issuing writes
   await new Promise((resolve) => setTimeout(resolve, 500));
   timer = setTimeout(() => {
@@ -76,6 +85,9 @@ async function main(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   await db.delete(tables.StreamingChannel, 'news_001');
+
+  // give the server a moment to emit the delete event
+  await new Promise((resolve) => setTimeout(resolve, 500));
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- start stream without awaiting so writes execute concurrently
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `cd examples && npm run gen:onyx`
- `cd examples && node --import=tsx --enable-source-maps stream/basic.ts` *(fails: OnyxConfigError: Missing required config: databaseId, apiKey, apiSecret)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1b7b46ec8321801ff6a4587a2d96