### PR TITLE
fix: start stream before issuing mutations

### DIFF
--- a/changelog/2025-08-25-0556pm-stream-example-wait.md
+++ b/changelog/2025-08-25-0556pm-stream-example-wait.md
@@ -1,0 +1,13 @@
+# Change: wait for stream before saves
+
+- Date: 2025-08-25 05:56 PM UTC
+- Author/Agent: ChatGPT
+- Scope: examples
+- Type: fix
+- Summary:
+  - start streaming example only after the stream handle resolves
+  - ensures subsequent saves occur after listeners are active
+- Impact:
+  - stream example reliably emits query and mutation events
+- Follow-ups:
+  - none

--- a/examples/stream/basic.ts
+++ b/examples/stream/basic.ts
@@ -46,18 +46,16 @@ async function main(): Promise<void> {
     });
 
   // keep the connection alive so subsequent saves trigger events
-  void stream
-    .stream(true, true)
-    .then((h) => {
-      handle = h;
-      console.log('Stream started');
-    })
-    .catch((err) => {
-      console.error('Stream failed', err);
-      cancel();
-    });
+  try {
+    handle = await stream.stream(true, true);
+    console.log('Stream started');
+  } catch (err) {
+    console.error('Stream failed', err);
+    cancel();
+    return;
+  }
 
-  // allow the subscription to fully register before issuing writes
+  // allow the server to flush initial results before issuing writes
   await new Promise((resolve) => setTimeout(resolve, 500));
   timer = setTimeout(() => {
     console.log('Stream timed out, cancelling');


### PR DESCRIPTION
## Summary
- ensure streaming example waits for listener initialization before issuing saves
- document change

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aca372991483219a2f959e992a5eee