### PR TITLE
fix: reconnect stream polling

### DIFF
--- a/changelog/2025-08-25-1146am-stream-reconnect.md
+++ b/changelog/2025-08-25-1146am-stream-reconnect.md
@@ -1,0 +1,13 @@
+# Change: improve stream reconnection
+
+- Date: 2025-08-25 11:46 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - reconnect JSON-lines stream when server closes the connection
+  - ensure clients continue polling for new events
+- Impact:
+  maintains long-lived stream subscriptions without manual restarts
+- Follow-ups:
+  none

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -14,71 +14,85 @@ export async function openJsonLinesStream<T = unknown>(
   fetchImpl: FetchImpl,
   url: string,
   init: { method?: string; headers?: Record<string, string>; body?: string } = {},
-  handlers: StreamHandlers<T> = {}
+  handlers: StreamHandlers<T> = {},
 ): Promise<{ cancel: () => void }> {
-  const res = await fetchImpl(url, {
-    method: init.method ?? 'PUT',
-    headers: init.headers ?? {},
-    body: init.body
-  });
-
-  if (!res.ok) {
-    const raw = await res.text();
-    let parsed: unknown = raw;
-    try { parsed = parseJsonAllowNaN(raw); } catch { /* ignore */ }
-    throw new OnyxHttpError(`${res.status} ${res.statusText}`, res.status, res.statusText, parsed);
-  }
-
   interface Reader {
     cancel(): void;
     read(): Promise<{ done: boolean; value?: Uint8Array }>;
   }
   interface StreamBody { getReader(): Reader; }
-  const body = (res as { body?: StreamBody }).body;
-  if (!body || typeof body.getReader !== 'function') {
-    // Not a stream; nothing to read
-    return { cancel: () => { /* noop */ } };
-  }
 
-  const reader = body.getReader();
   const decoder = new TextDecoder('utf-8');
   let buffer = '';
   let canceled = false;
+  let currentReader: Reader | null = null;
 
-  const handle = {
-    cancel() {
-      if (canceled) return;
-      canceled = true;
-      try { reader.cancel(); } catch { /* ignore */ }
-    }
-  };
-
-  const processLine = (line: string) => {
+  const processLine = (line: string): void => {
     const trimmed = line.trim();
     if (!trimmed) return;
     let obj: unknown;
     try { obj = parseJsonAllowNaN(trimmed); } catch { return; }
     const action = (obj as { action?: StreamAction }).action;
     const entity = (obj as { entity?: T | null }).entity;
-
     if (action === 'CREATE') handlers.onItemAdded?.(entity as T);
     else if (action === 'UPDATE') handlers.onItemUpdated?.(entity as T);
     else if (action === 'DELETE') handlers.onItemDeleted?.(entity as T);
     if (action && action !== 'KEEP_ALIVE') handlers.onItem?.(entity ?? null, action);
   };
 
-  const pump = (): void => {
+  const connect = async (): Promise<void> => {
     if (canceled) return;
-    reader.read().then(({ done, value }) => {
-      if (canceled || done) return;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop() ?? '';
-      for (const line of lines) processLine(line);
+    try {
+      const res = await fetchImpl(url, {
+        method: init.method ?? 'PUT',
+        headers: init.headers ?? {},
+        body: init.body,
+      });
+      if (!res.ok) {
+        const raw = await res.text();
+        let parsed: unknown = raw;
+        try { parsed = parseJsonAllowNaN(raw); } catch { /* ignore */ }
+        throw new OnyxHttpError(`${res.status} ${res.statusText}`, res.status, res.statusText, parsed);
+      }
+      const body = (res as { body?: StreamBody }).body;
+      if (!body || typeof body.getReader !== 'function') return;
+      currentReader = body.getReader();
       pump();
-    }).catch(() => { /* ignore errors on read loop */ });
+    } catch {
+      if (canceled) return;
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      void connect();
+    }
   };
 
-  pump();
-  return handle;
+  const pump = (): void => {
+    if (canceled || !currentReader) return;
+    currentReader
+      .read()
+      .then(({ done, value }) => {
+        if (canceled) return;
+        if (done) {
+          void connect();
+          return;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) processLine(line);
+        pump();
+      })
+      .catch(() => {
+        if (!canceled) void connect();
+      });
+  };
+
+  await connect();
+
+  return {
+    cancel() {
+      if (canceled) return;
+      canceled = true;
+      try { currentReader?.cancel(); } catch { /* ignore */ }
+    }
+  };
 }


### PR DESCRIPTION
## Summary
- retry JSON-lines stream when server closes connection
- log changelog entry for stream reconnection

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acae65ece48321810efd0e92308e87