### PR TITLE
fix: request ndjson for streaming queries

### DIFF
--- a/changelog/2025-08-25-0137pm-stream-content-type.md
+++ b/changelog/2025-08-25-0137pm-stream-content-type.md
@@ -1,0 +1,13 @@
+# Change: set content type for streaming queries
+
+- Date: 2025-08-25 01:37 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - explicitly send `Content-Type: application/json` when opening streaming queries
+  - rely on HttpClient to include authentication headers
+- Impact:
+  - ensures streaming requests are properly authenticated and parsed
+- Follow-ups:
+  - none

--- a/changelog/2025-08-25-1224pm-stream-accept-ndjson.md
+++ b/changelog/2025-08-25-1224pm-stream-accept-ndjson.md
@@ -1,0 +1,13 @@
+# Change: fix stream Accept header for ndjson
+
+- Date: 2025-08-25 12:24 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - request streaming queries with `application/x-ndjson`
+  - enables stream example to receive item events
+- Impact:
+  - streaming subscriptions now emit change events
+- Follow-ups:
+  - none

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -311,7 +311,14 @@ class OnyxDatabaseImpl<Schema = Record<string, unknown>> implements IOnyxDatabas
     const handle = await openJsonLinesStream<T>(
       fetchImpl,
       url,
-      { method: 'PUT', headers: http.headers(), body: JSON.stringify(serializeDates(select)) },
+      {
+        method: 'PUT',
+        headers: http.headers({
+          Accept: 'application/x-ndjson',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify(serializeDates(select)),
+      },
       handlers,
     );
     return this.registerStream(handle);


### PR DESCRIPTION
## Summary
- send `Accept: application/x-ndjson` and `Content-Type: application/json` when opening streaming queries
- record change in changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `cd examples && npx tsx stream/basic.ts` *(fails: Cannot find module '/workspace/onyx-database/examples/onyx/types')*


------
https://chatgpt.com/codex/tasks/task_e_68acb7f75e54832186b9c2b9bd66ce25