### PR TITLE
fix: normalize stream actions in stream reader

### DIFF
--- a/changelog/2025-08-25-0428pm-stream-action-parsing.md
+++ b/changelog/2025-08-25-0428pm-stream-action-parsing.md
@@ -1,0 +1,13 @@
+# Change: normalize stream actions
+
+- Date: 2025-08-25 04:28 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Handle additional stream action names (`event` field and lowercase values`).
+  - Map common synonyms to canonical actions so item handlers fire reliably.
+- Impact:
+  - Ensures streaming examples receive add/update/delete callbacks.
+- Follow-ups:
+  - None

--- a/examples/stream/basic.ts
+++ b/examples/stream/basic.ts
@@ -66,6 +66,7 @@ async function main(): Promise<void> {
     id: 'news_001',
     category: 'news',
     name: 'News 24',
+    icon: null,
     updatedAt: new Date(),
   });
 
@@ -76,6 +77,7 @@ async function main(): Promise<void> {
     id: 'news_001',
     category: 'news',
     name: 'News 24 - Updated',
+    icon: null,
     updatedAt: new Date(),
   });
 


### PR DESCRIPTION
## Summary
- normalize action parsing in stream reader to handle alternate field names and case
- update streaming example to include required icon field
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm --prefix examples run gen:onyx`
- `cd examples && npx tsx stream/basic.ts` *(fails: OnyxConfigError: Missing required config: databaseId, apiKey, apiSecret)*

------
https://chatgpt.com/codex/tasks/task_e_68acf0ad62c8832198a0dbb0ab1b7502