### PR TITLE
fix: handle stream write failures in example

### DIFF
--- a/changelog/2025-08-25-0458pm-stream-example-write-failure.md
+++ b/changelog/2025-08-25-0458pm-stream-example-write-failure.md
@@ -1,0 +1,12 @@
+# Change: handle write failures in stream example
+
+- Date: 2025-08-25 04:58 PM PT
+- Author/Agent: ChatGPT
+- Scope: examples
+- Type: fix
+- Summary:
+  - wrap stream writes in try/catch to cancel on error
+- Impact:
+  - stream example exits gracefully when writes fail
+- Follow-ups:
+  - none

--- a/examples/stream/basic.ts
+++ b/examples/stream/basic.ts
@@ -62,32 +62,38 @@ async function main(): Promise<void> {
     cancel();
   }, 10_000);
 
-  await db.save(tables.StreamingChannel, {
-    id: 'news_001',
-    category: 'news',
-    name: 'News 24',
-    icon: null,
-    updatedAt: new Date(),
-  });
+  try {
+    await db.save(tables.StreamingChannel, {
+      id: 'news_001',
+      category: 'news',
+      name: 'News 24',
+      icon: null,
+      updatedAt: new Date(),
+    });
 
-  // give the server a moment to emit the add event
-  await new Promise((resolve) => setTimeout(resolve, 500));
+    // give the server a moment to emit the add event
+    await new Promise((resolve) => setTimeout(resolve, 500));
 
-  await db.save(tables.StreamingChannel, {
-    id: 'news_001',
-    category: 'news',
-    name: 'News 24 - Updated',
-    icon: null,
-    updatedAt: new Date(),
-  });
+    await db.save(tables.StreamingChannel, {
+      id: 'news_001',
+      category: 'news',
+      name: 'News 24 - Updated',
+      icon: null,
+      updatedAt: new Date(),
+    });
 
-  // allow the update event to flush before deletion
-  await new Promise((resolve) => setTimeout(resolve, 500));
+    // allow the update event to flush before deletion
+    await new Promise((resolve) => setTimeout(resolve, 500));
 
-  await db.delete(tables.StreamingChannel, 'news_001');
+    await db.delete(tables.StreamingChannel, 'news_001');
 
-  // give the server a moment to emit the delete event
-  await new Promise((resolve) => setTimeout(resolve, 500));
+    // give the server a moment to emit the delete event
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  } catch (err) {
+    console.error('Write failed', err);
+    cancel();
+    return;
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- cancel stream example when database writes fail
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run gen:onyx`
- `npx tsx stream/basic.ts` *(fails: Missing required config)*

------
https://chatgpt.com/codex/tasks/task_e_68acf82423d8832183c28d5017d98ec1