### PR TITLE
fix: broaden stream action detection

### DIFF
--- a/changelog/2025-08-25-0603pm-stream-event-parsing.md
+++ b/changelog/2025-08-25-0603pm-stream-event-parsing.md
@@ -1,0 +1,13 @@
+# Change: broaden stream action detection
+
+- Date: 2025-08-25 06:03 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - recognize additional action field names when processing stream events
+  - handle extra synonyms for creation events (INSERT, CREATED)
+- Impact:
+  - ensures stream callbacks fire for add, update, and delete events
+- Follow-ups:
+  - none

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -37,18 +37,63 @@ export async function openJsonLinesStream<T = unknown>(
       return;
     }
     const rawAction =
-      (obj as { action?: string; event?: string }).action ??
-      (obj as { action?: string; event?: string }).event;
+      (obj as {
+        action?: string;
+        event?: string;
+        type?: string;
+        eventType?: string;
+        changeType?: string;
+      }).action ??
+      (obj as {
+        action?: string;
+        event?: string;
+        type?: string;
+        eventType?: string;
+        changeType?: string;
+      }).event ??
+      (obj as {
+        action?: string;
+        event?: string;
+        type?: string;
+        eventType?: string;
+        changeType?: string;
+      }).type ??
+      (obj as {
+        action?: string;
+        event?: string;
+        type?: string;
+        eventType?: string;
+        changeType?: string;
+      }).eventType ??
+      (obj as {
+        action?: string;
+        event?: string;
+        type?: string;
+        eventType?: string;
+        changeType?: string;
+      }).changeType;
     const entity = (obj as { entity?: T | null }).entity;
     const action = rawAction?.toUpperCase();
-    if (action === 'CREATE' || action === 'ADDED' || action === 'ADD')
+    if (
+      action === 'CREATE' ||
+      action === 'CREATED' ||
+      action === 'ADDED' ||
+      action === 'ADD' ||
+      action === 'INSERT' ||
+      action === 'INSERTED'
+    )
       handlers.onItemAdded?.(entity as T);
     else if (action === 'UPDATE' || action === 'UPDATED')
       handlers.onItemUpdated?.(entity as T);
     else if (action === 'DELETE' || action === 'DELETED' || action === 'REMOVE' || action === 'REMOVED')
       handlers.onItemDeleted?.(entity as T);
     const canonical =
-      action === 'ADDED' || action === 'ADD' || action === 'CREATE' || action === 'CREATED'
+      action === 'ADDED' ||
+      action === 'ADD' ||
+      action === 'CREATE' ||
+      action === 'CREATED' ||
+      action === 'INSERT' ||
+      action === 'INSERTED'
         ? 'CREATE'
         : action === 'UPDATED' || action === 'UPDATE'
           ? 'UPDATE'


### PR DESCRIPTION
## Summary
- expand stream event parsing to recognize additional action fields and creation synonyms
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad07148570832199b9859a35f5fdb5