### PR TITLE
fix: retry transient HTTP errors

### DIFF
--- a/changelog/2025-08-26-0455am-retry-http-requests.md
+++ b/changelog/2025-08-26-0455am-retry-http-requests.md
@@ -1,0 +1,13 @@
+# Change: retry transient HTTP errors
+
+- Date: 2025-08-26 04:55 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - add simple retry/backoff logic to HttpClient for 5xx responses
+  - cover retry behavior with unit tests
+- Impact:
+  - improves resilience to temporary network issues such as Cloudflare 524 timeouts
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- add simple retry/backoff logic in `HttpClient` for 5xx responses or fetch failures
- cover retry behavior with unit tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad3cf7d5b083218f60c92ef6be729f