### PR TITLE
fix: handle SSE lines in stream

### DIFF
--- a/changelog/2025-08-26-0518am-stream-sse.md
+++ b/changelog/2025-08-26-0518am-stream-sse.md
@@ -1,0 +1,13 @@
+# Change: handle SSE data prefix in stream parsing
+
+- Date: 2025-08-26 05:18 AM UTC
+- Author/Agent: OpenAI ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Strip `data:` prefixes and ignore comment lines when parsing stream payloads
+  - Add unit test verifying SSE formatted lines are processed
+- Impact:
+  - Streaming queries now process Server-Sent Events payloads correctly
+- Follow-ups:
+  - none

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -29,10 +29,11 @@ export async function openJsonLinesStream<T = unknown>(
 
   const processLine = (line: string): void => {
     const trimmed = line.trim();
-    if (!trimmed) return;
+    if (!trimmed || trimmed.startsWith(':')) return;
+    const jsonLine = trimmed.startsWith('data:') ? trimmed.slice(5).trim() : trimmed;
     let obj: unknown;
     try {
-      obj = parseJsonAllowNaN(trimmed);
+      obj = parseJsonAllowNaN(jsonLine);
     } catch {
       return;
     }

--- a/tests/stream.spec.ts
+++ b/tests/stream.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { openJsonLinesStream } from '../src/core/stream';
+
+const te = new TextEncoder();
+
+describe('openJsonLinesStream', () => {
+  it('parses SSE data lines', async () => {
+    const reader = {
+      cancel: vi.fn(),
+      read: vi
+        .fn<[], Promise<{ done: boolean; value?: Uint8Array }>>()
+        .mockResolvedValueOnce({ done: false, value: te.encode('data: {"action":"CREATE","entity":{"id":1}}\n') })
+        .mockResolvedValueOnce({ done: false, value: te.encode('data: {"action":"KEEP_ALIVE","entity":null}\n') })
+        .mockImplementation(() => new Promise(() => {})),
+    };
+    const fetchImpl = vi
+      .fn<[string, any], Promise<any>>()
+      .mockResolvedValue({ ok: true, status: 200, statusText: 'OK', body: { getReader: () => reader } });
+
+    const actions: string[] = [];
+    const handle = await openJsonLinesStream<any>(fetchImpl as any, 'url', {}, {
+      onItem: (_e, a) => actions.push(a),
+    });
+    // allow the pump loop to process queued chunks
+    await new Promise((r) => setTimeout(r, 0));
+    handle.cancel();
+    expect(actions).toEqual(['CREATE']);
+  });
+});


### PR DESCRIPTION
## Summary
- strip `data:` prefixes and ignore comments in stream payload parser
- test SSE formatted stream handling

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm --prefix examples run gen:onyx`
- `npx --prefix examples tsx examples/stream/basic.ts` *(fails: Missing required config: databaseId, apiKey, apiSecret)*

------
https://chatgpt.com/codex/tasks/task_e_68ad42b8a7588321ba6f01658462081a