### PR TITLE
docs: update examples for singular tables

### DIFF
--- a/changelog/2025-08-26-0624pm-update-examples-singular-tables.md
+++ b/changelog/2025-08-26-0624pm-update-examples-singular-tables.md
@@ -1,0 +1,14 @@
+# Change: update examples for singular table names
+
+- Date: 2025-08-26 06:24 PM PT
+- Author/Agent: ChatGPT
+- Scope: examples
+- Type: docs
+- Summary:
+  - Replace plural table enum references with singular names in example code
+  - Aligns examples with updated schema naming
+- Impact:
+  - No API changes; examples now match generated types
+- Follow-ups:
+  - None
+

--- a/examples/delete/basic.ts
+++ b/examples/delete/basic.ts
@@ -7,7 +7,7 @@ async function main(): Promise<void> {
   const db = onyx.init<Schema>();
 
   const deleted = (await db
-    .from(tables.Users)
+    .from(tables.User)
     .where(eq('username', 'obsolete'))
     .delete()) as number;
 

--- a/examples/query/aggregate-sum.ts
+++ b/examples/query/aggregate-sum.ts
@@ -8,7 +8,7 @@ async function main(): Promise<void> {
 
   const stats = await db
     .select(count('id'))
-    .from(tables.Users)
+    .from(tables.User)
     .list();
 
   console.log(JSON.stringify(stats, null, 2)); // [{"count(id)": 3}]

--- a/examples/query/aggregates-with-grouping.ts
+++ b/examples/query/aggregates-with-grouping.ts
@@ -8,7 +8,7 @@ async function main(): Promise<void> {
 
   const stats = await db
     .select('isActive', count('id'))
-    .from(tables.Users)
+    .from(tables.User)
     .groupBy('isActive')
     .list();
 

--- a/examples/query/basic.ts
+++ b/examples/query/basic.ts
@@ -7,7 +7,7 @@ async function main(): Promise<void> {
   const db = onyx.init<Schema>();
 
   const recentActive = await db
-    .from(tables.Users)
+    .from(tables.User)
     .where(eq('isActive', true))
     .and(gt('createdAt', new Date('2024-01-01')))
     .limit(5)

--- a/examples/query/find-by-id.ts
+++ b/examples/query/find-by-id.ts
@@ -8,7 +8,7 @@ async function main(): Promise<void> {
   const id = 'user_001';
 
   try {
-    const user = await db.findById(tables.Users, id);
+    const user = await db.findById(tables.User, id);
     if (!user) {
       console.log('No record found for id:', id);
       return;

--- a/examples/query/first-or-null.ts
+++ b/examples/query/first-or-null.ts
@@ -7,14 +7,14 @@ async function main(): Promise<void> {
   const db = onyx.init<Schema>();
 
   const maybeUser = await db
-    .from(tables.Users)
+    .from(tables.User)
     .where(eq('username', 'superman'))
     .firstOrNull();
 
   console.log(JSON.stringify(maybeUser, null, 2));
 
   const alsoUser = await db
-    .from(tables.Users)
+    .from(tables.User)
     .where(eq('username', 'DNE'))
     .one();
 

--- a/examples/query/resolver.ts
+++ b/examples/query/resolver.ts
@@ -6,7 +6,7 @@ async function main(): Promise<void> {
   const db = onyx.init<Schema>();
 
   const usersWithRoles = await db
-    .from(tables.Users)
+    .from(tables.User)
     .resolve('roles')
     .limit(5)
     .list();

--- a/examples/query/select.ts
+++ b/examples/query/select.ts
@@ -8,7 +8,7 @@ async function main(): Promise<void> {
 
   const users = await db
     .select('username', 'email')
-    .from(tables.Users)
+    .from(tables.User)
     .limit(5)
     .list();
 

--- a/examples/save/basic.ts
+++ b/examples/save/basic.ts
@@ -6,7 +6,7 @@ import { tables, Schema } from 'onyx/types';
 async function main(): Promise<void> {
   const db = onyx.init<Schema>();
 
-  const user = await db.save(tables.Users, {
+  const user = await db.save(tables.User, {
     id: 'user_basic',
     username: 'basic',
     email: 'basic@example.com',

--- a/examples/save/cascade.ts
+++ b/examples/save/cascade.ts
@@ -1,7 +1,7 @@
 // filename: examples/save/cascade.ts
 import process from 'node:process';
 import { eq, onyx } from '@onyx.dev/onyx-database';
-import { Schema, tables, UserProfile, Users } from 'onyx/types';
+import { Schema, tables, UserProfile, User } from 'onyx/types';
 
 async function main(): Promise<void> {
   const db = onyx.init<Schema>();
@@ -20,9 +20,9 @@ async function main(): Promise<void> {
     deletedAt: null,
   };
 
-  const newUser: Users = await db
+  const newUser: User = await db
     .cascade('profile:UserProfile(userId, id)')
-    .save(tables.Users, {
+    .save(tables.User, {
       id: 'cascade_001',
       username: 'cascade',
       email: 'cascade@example.com',
@@ -30,12 +30,12 @@ async function main(): Promise<void> {
       createdAt: new Date(),
       updatedAt: new Date(),
       profile,
-    }) as Users;
+    }) as User;
 
   console.log('Saved user:', newUser);
 
   const users = await db
-    .from(tables.Users)
+    .from(tables.User)
     .where(eq('id', newUser.id))
     .resolve('profile')
     .limit(1)
@@ -44,7 +44,7 @@ async function main(): Promise<void> {
   console.log('user with profile:', JSON.stringify(users, null, 2));
 
   // cleanup
-  await db.cascade('profile').delete(tables.Users, newUser.id!);
+  await db.cascade('profile').delete(tables.User, newUser.id!);
 }
 
 main().catch((err) => {

--- a/examples/save/save.ts
+++ b/examples/save/save.ts
@@ -6,7 +6,7 @@ import { Schema, tables } from 'onyx/types';
 async function main(): Promise<void> {
   const db = onyx.init<Schema>();
 
-  const role = await db.save(tables.Roles, {
+  const role = await db.save(tables.Role, {
     id: 'role_admin',
     name: 'admin',
     description: 'Administrator role',

--- a/examples/stream/basic.ts
+++ b/examples/stream/basic.ts
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
   };
 
   const stream = streamDb
-    .from(tables.Users)
+    .from(tables.User)
     .where(eq('isActive', true))
     .onItemAdded((item) => {
       console.log('ITEM ADDED', item);
@@ -66,7 +66,7 @@ async function main(): Promise<void> {
   }, 10_000);
 
   try {
-    await writeDb.save(tables.Users, {
+    await writeDb.save(tables.User, {
       id: 'stream_user_001',
       username: 'stream_user',
       email: 'stream@example.com',
@@ -79,7 +79,7 @@ async function main(): Promise<void> {
     // give the server a moment to emit the add event
     await new Promise((resolve) => setTimeout(resolve, 500));
 
-    await writeDb.save(tables.Users, {
+    await writeDb.save(tables.User, {
       id: 'stream_user_001',
       username: 'stream_user_updated',
       email: 'stream@example.com',
@@ -92,7 +92,7 @@ async function main(): Promise<void> {
     // allow the update event to flush before deletion
     await new Promise((resolve) => setTimeout(resolve, 500));
 
-    await writeDb.delete(tables.Users, 'stream_user_001');
+    await writeDb.delete(tables.User, 'stream_user_001');
 
     // give the server a moment to emit the delete event
     await new Promise((resolve) => setTimeout(resolve, 500));


### PR DESCRIPTION
## Summary
- update example code to reference singular table enum names
- record changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `(in examples/) npm run gen:onyx`
- `(in examples/) npm start` *(fails: Missing script "start")*

------
https://chatgpt.com/codex/tasks/task_e_68ae5e0dc14883219b5996669a6dcd22