### PR TITLE
refactor: remove Node runtime assumptions

### DIFF
--- a/changelog/2025-08-27-0917pm-runtime-agnostic.md
+++ b/changelog/2025-08-27-0917pm-runtime-agnostic.md
@@ -1,0 +1,14 @@
+# Change: remove Node runtime assumptions
+
+- Date: 2025-08-27 09:17 PM PT
+- Author/Agent: openai-assistant
+- Scope: lib
+- Type: refactor
+- Summary:
+  - Dropped project/home file resolution and `process` imports to enable non-Node runtimes.
+  - Config now resolves from env (when available) or explicit input only.
+  - Build targets neutral platform; docs and tests updated.
+- Impact:
+  - Library can run in Cloudflare Workers and other environments without Node APIs.
+- Follow-ups:
+  - None

--- a/changelog/2025-08-27-0934pm-node-file-config.md
+++ b/changelog/2025-08-27-0934pm-node-file-config.md
@@ -1,0 +1,15 @@
+# Change: restore file-based config resolution
+
+- Date: 2025-08-27 09:34 PM PT
+- Author/Agent: codex
+- Scope: lib
+- Type: fix
+- Summary:
+  - reintroduced project and home JSON config files when running on Node.js
+  - skip file system lookups in non-Node environments
+  - updated docs and tests for file-based config
+- Impact:
+  - Node users can load credentials from local files; no change for edge runtimes
+- Follow-ups:
+  - none
+

--- a/codex/tasks/library-readiness/finished/020-runtime-agnostic.md
+++ b/codex/tasks/library-readiness/finished/020-runtime-agnostic.md
@@ -1,0 +1,19 @@
+# Task 020: runtime agnostic library
+
+## Task
+Refactor the library to remove Node.js runtime dependencies so it works in both Node and Cloudflare Workers.
+
+## Plan
+1. Replace direct `process` usage with optional `globalThis` checks.
+2. Drop project/home file config resolution and any `node:` imports.
+3. Update stream debug logging to use `globalThis.process`.
+4. Build the library for a neutral platform instead of Node.
+5. Update tests and README for the new config behavior.
+6. Add a changelog entry.
+
+## Acceptance Criteria
+- [x] No `node:` imports remain in library source.
+- [x] Config resolves from env or explicit input only.
+- [x] Build uses neutral platform and passes lint, typecheck, tests.
+- [x] README notes Cloudflare Workers support.
+- [x] Changelog entry added.

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -4,7 +4,7 @@ import { OnyxHttpError } from '../errors/http-error';
 import { parseJsonAllowNaN } from './http';
 
 const debug = (...args: unknown[]): void => {
-  if (typeof process !== 'undefined' && process.env.ONYX_STREAM_DEBUG)
+  if ((globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.ONYX_STREAM_DEBUG)
     console.log('[onyx-stream]', ...args);
 };
 

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -78,4 +78,12 @@ describe('config chain database selection', () => {
       await unlink(file);
     }
   });
+
+  it('throws when required config is missing', async () => {
+    delete process.env.ONYX_DATABASE_ID;
+    delete process.env.ONYX_DATABASE_API_KEY;
+    delete process.env.ONYX_DATABASE_API_SECRET;
+    await expect(resolveConfig()).rejects.toBeInstanceOf(OnyxConfigError);
+  });
 });
+

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig([
     target: 'es2022',
     sourcemap: true,
     minify: false,
+    platform: 'neutral',
   },
   // CLI bundle (no .d.ts)
   {
@@ -26,5 +27,6 @@ export default defineConfig([
     target: 'es2022',
     sourcemap: true,
     minify: false,
+    platform: 'node',
   },
 ]);


### PR DESCRIPTION
## Summary
- restore file-based config resolution in Node.js and skip when not in a Node runtime
- document Node-only config file support in README
- reinstate config-chain tests and add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `git push origin HEAD` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68afd6b372308321a449fdb91092d210