### PR TITLE
feat: return QueryResults from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ const firstPage = await db
   .and(contains('email', '@example.com'))
   .orderBy(asc('createdAt'))
   .limit(25)
-  .page(); // or .list() to get just records
+  .page(); // or .list() for array-like results with nextPage
 
 // Iterate to fetch all pages:
 const allActive = await db

--- a/changelog/2025-09-03-0633pm-query-results-list.md
+++ b/changelog/2025-09-03-0633pm-query-results-list.md
@@ -1,0 +1,13 @@
+# Change: return QueryResults from list()
+
+- Date: 2025-09-03 06:33 PM PT
+- Author/Agent: OpenAI Assistant
+- Scope: lib
+- Type: feat
+- Summary:
+  - list() now returns array-like QueryResults with nextPage metadata
+  - exposed QueryResults type in public API and docs
+- Impact:
+  - public API updated; list() callers can access nextPage on results
+- Follow-ups:
+  - none

--- a/docs/README.md
+++ b/docs/README.md
@@ -225,7 +225,7 @@ const firstPage = await db
   .and(contains('email', '@example.com'))
   .orderBy(asc('createdAt'))
   .limit(25)
-  .page(); // or .list() to get just records
+  .page(); // or .list() for array-like results with nextPage
 
 // Iterate to fetch all pages:
 const allActive = await db

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -18,6 +18,7 @@
 - [OnyxFacade](interfaces/OnyxFacade.md)
 - [QueryCriteria](interfaces/QueryCriteria.md)
 - [QueryPage](interfaces/QueryPage.md)
+- [QueryResults](interfaces/QueryResults.md)
 - [SelectQuery](interfaces/SelectQuery.md)
 - [Sort](interfaces/Sort.md)
 - [UpdateQuery](interfaces/UpdateQuery.md)

--- a/docs/interfaces/IQueryBuilder.md
+++ b/docs/interfaces/IQueryBuilder.md
@@ -144,9 +144,9 @@ Defined in: types/builders.ts:21
 
 ### list()
 
-> **list**(`options?`): `Promise`\<`T`[]\>
+> **list**(`options?`): `Promise`\<[`QueryResults`](QueryResults.md)\<`T`\>\>
 
-Defined in: types/builders.ts:28
+Defined in: types/builders.ts:32
 
 #### Parameters
 

--- a/docs/interfaces/QueryResults.md
+++ b/docs/interfaces/QueryResults.md
@@ -1,0 +1,23 @@
+[**@onyx.dev/onyx-database**](../README.md)
+
+***
+
+[@onyx.dev/onyx-database](../globals.md) / QueryResults
+
+# Interface: QueryResults<T> extends Array<T>
+
+Defined in: types/builders.ts:5
+
+## Type Parameters
+
+### T
+
+`T`
+
+## Properties
+
+### nextPage?
+
+> `optional` **nextPage**: `null` | `string`
+
+Defined in: types/builders.ts:6

--- a/src/builders/query-builder.ts
+++ b/src/builders/query-builder.ts
@@ -1,5 +1,5 @@
 // filename: src/builders/query-builder.ts
-import type { IQueryBuilder, IConditionBuilder } from '../types/builders';
+import type { IQueryBuilder, IConditionBuilder, QueryResults } from '../types/builders';
 import type {
   QueryCondition,
   QueryCriteria,
@@ -474,9 +474,11 @@ export class QueryBuilder<T = unknown> implements IQueryBuilder<T> {
    * const users = await builder.list({ pageSize: 5 });
    * ```
    */
-  async list(options: { pageSize?: number; nextPage?: string } = {}): Promise<T[]> {
+  async list(options: { pageSize?: number; nextPage?: string } = {}): Promise<QueryResults<T>> {
     const pg = await this.page(options);
-    return Array.isArray(pg.records) ? pg.records : [];
+    const arr = (Array.isArray(pg.records) ? pg.records : []) as QueryResults<T>;
+    arr.nextPage = pg.nextPage ?? null;
+    return arr;
   }
 
   /**

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -10,6 +10,7 @@ import type {
   ICascadeBuilder,
   IConditionBuilder,
   ICascadeRelationshipBuilder,
+  QueryResults,
 } from '../types/builders';
 import type {
   QueryCriteria,
@@ -522,10 +523,12 @@ class QueryBuilderImpl<T = unknown, S = Record<string, unknown>> implements IQue
   async list(options: {
     pageSize?: number;
     nextPage?: string;
-  } = {}): Promise<T[]> {
+  } = {}): Promise<QueryResults<T>> {
     // Explicit annotation avoids TS7022 during dts emit.
     const pg: { records: T[]; nextPage?: string | null } = await this.page(options);
-    return Array.isArray(pg.records) ? pg.records : [];
+    const arr = (Array.isArray(pg.records) ? pg.records : []) as QueryResults<T>;
+    arr.nextPage = pg.nextPage ?? null;
+    return arr;
   }
 
   async firstOrNull(): Promise<T | null> {

--- a/src/types/builders.ts
+++ b/src/types/builders.ts
@@ -2,6 +2,10 @@
 import type { Sort, StreamAction } from './common';
 import type { QueryCondition, QueryCriteria } from './protocol';
 
+export interface QueryResults<T> extends Array<T> {
+  nextPage?: string | null;
+}
+
 export interface IConditionBuilder {
   and(condition: IConditionBuilder | QueryCriteria): IConditionBuilder;
   or(condition: IConditionBuilder | QueryCriteria): IConditionBuilder;
@@ -25,7 +29,7 @@ export interface IQueryBuilder<T = unknown> {
   nextPage(token: string): IQueryBuilder<T>;
 
   count(): Promise<number>;
-  list(options?: { pageSize?: number; nextPage?: string }): Promise<T[]>;
+  list(options?: { pageSize?: number; nextPage?: string }): Promise<QueryResults<T>>;
   firstOrNull(): Promise<T | null>;
   one(): Promise<T | null>;
   page(options?: { pageSize?: number; nextPage?: string }): Promise<{ records: T[]; nextPage?: string | null }>;

--- a/tests/query-builder.spec.ts
+++ b/tests/query-builder.spec.ts
@@ -43,8 +43,12 @@ describe('QueryBuilder', () => {
       .nextPage('tok');
 
     expect(await qb.count()).toBe(2);
-    expect(await qb.list()).toEqual([{ id: 1 }]);
-    expect(await qb.list()).toEqual([]);
+    const first = await qb.list();
+    expect(Array.from(first)).toEqual([{ id: 1 }]);
+    expect(first.nextPage).toBe('n1');
+    const second = await qb.list();
+    expect(Array.from(second)).toEqual([]);
+    expect(second.nextPage).toBeNull();
     await qb.page({ pageSize: 1, nextPage: 'x' });
     expect(exec.queryPage).toHaveBeenLastCalledWith('users', expect.any(Object), { pageSize: 5, nextPage: 'tok', partition: 'p1' });
     await qb.delete();


### PR DESCRIPTION
## Summary
- expose a QueryResults<T> type that carries a nextPage token while behaving like an array
- have query builder `.list()` return QueryResults<T>
- document list's array-like results and new QueryResults interface

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8eb907a808321b2bcac79d889a3a6