### PR TITLE
feat: expand query results helpers

### DIFF
--- a/changelog/2025-09-03-0749pm-query-results-enhancements.md
+++ b/changelog/2025-09-03-0749pm-query-results-enhancements.md
@@ -1,0 +1,14 @@
+# Change: enhance QueryResults with Kotlin parity
+
+- Date: 2025-09-03 07:49 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: feat
+- Summary:
+  - add QueryResults class with iteration helpers and numeric utilities
+  - connect list() to return QueryResults instances that handle pagination
+  - expose QueryResults via public exports and add coverage tests
+- Impact:
+  - users gain rich helpers for working with paged query results
+- Follow-ups:
+  - none

--- a/src/builders/query-builder.ts
+++ b/src/builders/query-builder.ts
@@ -1,5 +1,6 @@
 // filename: src/builders/query-builder.ts
-import type { IQueryBuilder, IConditionBuilder, QueryResults } from '../types/builders';
+import type { IQueryBuilder, IConditionBuilder } from '../types/builders';
+import { QueryResults } from './query-results';
 import type {
   QueryCondition,
   QueryCriteria,
@@ -476,9 +477,9 @@ export class QueryBuilder<T = unknown> implements IQueryBuilder<T> {
    */
   async list(options: { pageSize?: number; nextPage?: string } = {}): Promise<QueryResults<T>> {
     const pg = await this.page(options);
-    const arr = (Array.isArray(pg.records) ? pg.records : []) as QueryResults<T>;
-    arr.nextPage = pg.nextPage ?? null;
-    return arr;
+    const size = this.pageSizeValue ?? options.pageSize;
+    const fetcher = (token: string) => this.nextPage(token).list({ pageSize: size });
+    return new QueryResults<T>(Array.isArray(pg.records) ? pg.records : [], pg.nextPage ?? null, fetcher);
   }
 
   /**

--- a/src/builders/query-results.ts
+++ b/src/builders/query-results.ts
@@ -1,0 +1,128 @@
+export class QueryResults<T> extends Array<T> {
+  nextPage: string | null;
+  private readonly fetcher?: (token: string) => Promise<QueryResults<T>>;
+
+  constructor(records: T[], nextPage: string | null, fetcher?: (token: string) => Promise<QueryResults<T>>) {
+    super(...records);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.nextPage = nextPage;
+    this.fetcher = fetcher;
+  }
+
+  first(): T {
+    if (this.length === 0) throw new Error('QueryResults is empty');
+    return this[0];
+  }
+
+  firstOrNull(): T | null {
+    return this.length > 0 ? this[0] : null;
+  }
+
+  isEmpty(): boolean {
+    return this.length === 0;
+  }
+
+  size(): number {
+    return this.length;
+  }
+
+  forEachOnPage(action: (item: T) => void): void {
+    this.forEach(action);
+  }
+
+  async forEachAll(action: (item: T) => boolean | void | Promise<boolean | void>): Promise<void> {
+    await this.forEachPage(async records => {
+      for (const r of records) {
+        const res = await action(r);
+        if (res === false) return false;
+      }
+      return true;
+    });
+  }
+
+  async forEachPage(action: (records: T[]) => boolean | void | Promise<boolean | void>): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let page: QueryResults<T> | null = this;
+    while (page) {
+      const cont = await action(Array.from(page));
+      if (cont === false) return;
+      if (page.nextPage && page.fetcher) {
+        page = await page.fetcher(page.nextPage);
+      } else {
+        page = null;
+      }
+    }
+  }
+
+  async getAllRecords(): Promise<T[]> {
+    const all: T[] = [];
+    await this.forEachPage(records => {
+      all.push(...records);
+    });
+    return all;
+  }
+
+  async filterAll(predicate: (record: T) => boolean): Promise<T[]> {
+    const all = await this.getAllRecords();
+    return all.filter(predicate);
+  }
+
+  async mapAll<R>(transform: (record: T) => R): Promise<R[]> {
+    const all = await this.getAllRecords();
+    return all.map(transform);
+  }
+
+  async maxOfDouble(selector: (record: T) => number): Promise<number> {
+    const all = await this.getAllRecords();
+    return all.reduce((max, r) => Math.max(max, selector(r)), -Infinity);
+  }
+
+  async minOfDouble(selector: (record: T) => number): Promise<number> {
+    const all = await this.getAllRecords();
+    return all.reduce((min, r) => Math.min(min, selector(r)), Infinity);
+  }
+
+  async sumOfDouble(selector: (record: T) => number): Promise<number> {
+    const all = await this.getAllRecords();
+    return all.reduce((sum, r) => sum + selector(r), 0);
+  }
+
+  async maxOfFloat(selector: (record: T) => number): Promise<number> {
+    return this.maxOfDouble(selector);
+  }
+  async minOfFloat(selector: (record: T) => number): Promise<number> {
+    return this.minOfDouble(selector);
+  }
+  async sumOfFloat(selector: (record: T) => number): Promise<number> {
+    return this.sumOfDouble(selector);
+  }
+  async maxOfInt(selector: (record: T) => number): Promise<number> {
+    return this.maxOfDouble(selector);
+  }
+  async minOfInt(selector: (record: T) => number): Promise<number> {
+    return this.minOfDouble(selector);
+  }
+  async sumOfInt(selector: (record: T) => number): Promise<number> {
+    return this.sumOfDouble(selector);
+  }
+  async maxOfLong(selector: (record: T) => number): Promise<number> {
+    return this.maxOfDouble(selector);
+  }
+  async minOfLong(selector: (record: T) => number): Promise<number> {
+    return this.minOfDouble(selector);
+  }
+  async sumOfLong(selector: (record: T) => number): Promise<number> {
+    return this.sumOfDouble(selector);
+  }
+
+  async sumOfBigInt(selector: (record: T) => bigint): Promise<bigint> {
+    const all = await this.getAllRecords();
+    return all.reduce((sum, r) => sum + selector(r), 0n);
+  }
+
+  async forEachPageParallel(action: (item: T) => void | Promise<void>): Promise<void> {
+    await this.forEachPage(records => Promise.all(records.map(action)).then(() => true));
+  }
+}
+
+export default QueryResults;

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -10,8 +10,8 @@ import type {
   ICascadeBuilder,
   IConditionBuilder,
   ICascadeRelationshipBuilder,
-  QueryResults,
 } from '../types/builders';
+import { QueryResults } from '../builders/query-results';
 import type {
   QueryCriteria,
   QueryCondition,
@@ -545,9 +545,9 @@ class QueryBuilderImpl<T = unknown, S = Record<string, unknown>> implements IQue
   } = {}): Promise<QueryResults<T>> {
     // Explicit annotation avoids TS7022 during dts emit.
     const pg: { records: T[]; nextPage?: string | null } = await this.page(options);
-    const arr = (Array.isArray(pg.records) ? pg.records : []) as QueryResults<T>;
-    arr.nextPage = pg.nextPage ?? null;
-    return arr;
+    const size = this.pageSizeValue ?? options.pageSize;
+    const fetcher = (token: string) => this.nextPage(token).list({ pageSize: size });
+    return new QueryResults<T>(Array.isArray(pg.records) ? pg.records : [], pg.nextPage ?? null, fetcher);
   }
 
   async firstOrNull(): Promise<T | null> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,6 @@ export { onyx } from './impl/onyx';
 export * from './helpers/sort';        // asc, desc
 export * from './helpers/conditions';  // eq, neq, inOp, ...
 export * from './helpers/aggregates';  // avg, sum, count, ...
+
+// Query result helper
+export { QueryResults } from './builders/query-results';

--- a/src/types/builders.ts
+++ b/src/types/builders.ts
@@ -1,10 +1,7 @@
 // filename: src/types/builders.ts
 import type { Sort, StreamAction } from './common';
 import type { QueryCondition, QueryCriteria } from './protocol';
-
-export interface QueryResults<T> extends Array<T> {
-  nextPage?: string | null;
-}
+import type { QueryResults } from '../builders/query-results';
 
 export interface IConditionBuilder {
   and(condition: IConditionBuilder | QueryCriteria): IConditionBuilder;
@@ -46,6 +43,8 @@ export interface IQueryBuilder<T = unknown> {
   streamEventsOnly(keepAlive?: boolean): Promise<{ cancel: () => void }>;
   streamWithQueryResults(keepAlive?: boolean): Promise<{ cancel: () => void }>;
 }
+
+export type { QueryResults } from '../builders/query-results';
 
 export interface ISaveBuilder<T = unknown> {
   cascade(...relationships: string[]): ISaveBuilder<T>;

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -5,7 +5,10 @@ import type {
   ICascadeBuilder,
   ISaveBuilder,
   ICascadeRelationshipBuilder,
+  QueryResults,
 } from './builders';
+
+export type { QueryResults };
 
 export interface OnyxConfig {
   baseUrl?: string;

--- a/tests/query-results.spec.ts
+++ b/tests/query-results.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QueryBuilder } from '../src/builders/query-builder';
+
+function makeExec() {
+  return {
+    count: vi.fn(),
+    queryPage: vi.fn().mockImplementation((_table, _select, opts) => {
+      if (!opts.nextPage) return Promise.resolve({ records: [{ id: 1 }, { id: 2 }], nextPage: 'n1' });
+      if (opts.nextPage === 'n1') return Promise.resolve({ records: [{ id: 3 }], nextPage: null });
+      return Promise.resolve({ records: [], nextPage: null });
+    }),
+    update: vi.fn(),
+    deleteByQuery: vi.fn(),
+    stream: vi.fn(),
+  };
+}
+
+describe('QueryResults', () => {
+  it('iterates records across pages and exposes helpers', async () => {
+    const exec = makeExec();
+    const qb = new QueryBuilder(exec as any, 'users');
+    const res = await qb.list();
+
+    expect(res.first()).toEqual({ id: 1 });
+    expect(res.firstOrNull()).toEqual({ id: 1 });
+    expect(res.isEmpty()).toBe(false);
+    expect(res.size()).toBe(2);
+
+    let onPage = 0;
+    res.forEachOnPage(() => {
+      onPage++;
+    });
+    expect(onPage).toBe(2);
+
+    const ids: number[] = [];
+    await res.forEachPage(page => {
+      ids.push(...page.map(r => r.id));
+      return true;
+    });
+    expect(ids).toEqual([1, 2, 3]);
+    expect(exec.queryPage).toHaveBeenCalledTimes(2);
+    // cover branch where action returns false
+    await res.forEachPage(() => false);
+
+    const all = await res.getAllRecords();
+    expect(all.map(r => r.id)).toEqual([1, 2, 3]);
+
+    const filtered = await res.filterAll(r => r.id > 1);
+    expect(filtered.map(r => r.id)).toEqual([2, 3]);
+
+    const mapped = await res.mapAll(r => r.id);
+    expect(mapped).toEqual([1, 2, 3]);
+
+    expect(await res.maxOfInt(r => r.id)).toBe(3);
+    expect(await res.sumOfInt(r => r.id)).toBe(6);
+    expect(await res.minOfInt(r => r.id)).toBe(1);
+    expect(await res.maxOfDouble(r => r.id)).toBe(3);
+    expect(await res.minOfDouble(r => r.id)).toBe(1);
+    expect(await res.sumOfDouble(r => r.id)).toBe(6);
+    expect(await res.maxOfFloat(r => r.id)).toBe(3);
+    expect(await res.minOfFloat(r => r.id)).toBe(1);
+    expect(await res.sumOfFloat(r => r.id)).toBe(6);
+    expect(await res.maxOfLong(r => r.id)).toBe(3);
+    expect(await res.minOfLong(r => r.id)).toBe(1);
+    expect(await res.sumOfLong(r => r.id)).toBe(6);
+    expect(await res.sumOfBigInt(r => BigInt(r.id))).toBe(6n);
+
+    const seen: number[] = [];
+    await res.forEachAll(r => {
+      seen.push(r.id);
+    });
+    expect(seen).toEqual([1, 2, 3]);
+
+    const limited: number[] = [];
+    await res.forEachAll(r => {
+      limited.push(r.id);
+      return r.id < 2;
+    });
+    expect(limited).toEqual([1, 2]);
+
+    let parallel = 0;
+    await res.forEachPageParallel(async r => {
+      parallel += r.id;
+    });
+    expect(parallel).toBe(6);
+
+    const empty = new (res.constructor as any)([], null);
+    expect(empty.firstOrNull()).toBeNull();
+    expect(() => empty.first()).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce QueryResults class with pagination-aware helpers and numeric aggregations
- wire query builders to return QueryResults instances
- expose QueryResults publicly and test its utilities

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8fda16b408321b02d31ce3854881d