### PR TITLE
docs: document query types and builders

### DIFF
--- a/changelog/2025-09-03-0808pm-query-type-docs.md
+++ b/changelog/2025-09-03-0808pm-query-type-docs.md
@@ -1,0 +1,12 @@
+# Change: document query types and builders
+
+- Date: 2025-09-03 08:08 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: docs
+- Summary:
+  - add JSDoc comments with parameter docs and examples for query types, builders, and utilities
+- Impact:
+  - documentation only; no runtime behavior changes
+- Follow-ups:
+  - none

--- a/src/builders/query-results.ts
+++ b/src/builders/query-results.ts
@@ -1,7 +1,27 @@
+/**
+ * Array-like container for paginated query results. Provides helper methods
+ * to traverse and aggregate records across pages.
+ *
+ * @example
+ * ```ts
+ * const results = new QueryResults(users, nextToken, fetchNext);
+ * const firstUser = results.first();
+ * ```
+ */
 export class QueryResults<T> extends Array<T> {
+  /** Token for the next page of results or null. */
   nextPage: string | null;
   private readonly fetcher?: (token: string) => Promise<QueryResults<T>>;
 
+  /**
+    * @param records - Records in the current page.
+    * @param nextPage - Token representing the next page.
+    * @param fetcher - Function used to fetch the next page when needed.
+    * @example
+    * ```ts
+    * const results = new QueryResults(users, token, t => fetchMore(t));
+    * ```
+    */
   constructor(records: T[], nextPage: string | null, fetcher?: (token: string) => Promise<QueryResults<T>>) {
     super(...records);
     Object.setPrototypeOf(this, new.target.prototype);
@@ -9,27 +29,75 @@ export class QueryResults<T> extends Array<T> {
     this.fetcher = fetcher;
   }
 
+  /**
+   * Returns the first record in the result set.
+   * @throws Error if the result set is empty.
+   * @example
+   * ```ts
+   * const user = results.first();
+   * ```
+   */
   first(): T {
     if (this.length === 0) throw new Error('QueryResults is empty');
     return this[0];
   }
 
+  /**
+   * Returns the first record or `null` if the result set is empty.
+   * @example
+   * ```ts
+   * const user = results.firstOrNull();
+   * ```
+   */
   firstOrNull(): T | null {
     return this.length > 0 ? this[0] : null;
   }
 
+  /**
+   * Checks whether the current page has no records.
+   * @example
+   * ```ts
+   * if (results.isEmpty()) console.log('no data');
+   * ```
+   */
   isEmpty(): boolean {
     return this.length === 0;
   }
 
+  /**
+   * Number of records on the current page.
+   * @example
+   * ```ts
+   * console.log(results.size());
+   * ```
+   */
   size(): number {
     return this.length;
   }
 
+  /**
+   * Iterates over each record on the current page only.
+   * @param action - Function to invoke for each record.
+   * @example
+   * ```ts
+   * results.forEachOnPage(u => console.log(u.id));
+   * ```
+   */
   forEachOnPage(action: (item: T) => void): void {
     this.forEach(action);
   }
 
+  /**
+   * Iterates over every record across all pages sequentially.
+   * @param action - Function executed for each record. Returning `false`
+   *                 stops iteration early.
+   * @example
+   * ```ts
+   * await results.forEachAll(u => {
+   *   if (u.disabled) return false;
+   * });
+   * ```
+   */
   async forEachAll(action: (item: T) => boolean | void | Promise<boolean | void>): Promise<void> {
     await this.forEachPage(async records => {
       for (const r of records) {
@@ -40,6 +108,17 @@ export class QueryResults<T> extends Array<T> {
     });
   }
 
+  /**
+   * Iterates page by page across the result set.
+   * @param action - Function invoked with each page of records. Returning
+   *                 `false` stops iteration.
+   * @example
+   * ```ts
+   * await results.forEachPage(page => {
+   *   console.log(page.length);
+   * });
+   * ```
+   */
   async forEachPage(action: (records: T[]) => boolean | void | Promise<boolean | void>): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let page: QueryResults<T> | null = this;
@@ -54,6 +133,14 @@ export class QueryResults<T> extends Array<T> {
     }
   }
 
+  /**
+   * Collects all records from every page into a single array.
+   * @returns All records.
+   * @example
+   * ```ts
+   * const allUsers = await results.getAllRecords();
+   * ```
+   */
   async getAllRecords(): Promise<T[]> {
     const all: T[] = [];
     await this.forEachPage(records => {
@@ -62,64 +149,156 @@ export class QueryResults<T> extends Array<T> {
     return all;
   }
 
+  /**
+   * Filters all records using the provided predicate.
+   * @param predicate - Function used to test each record.
+   * @example
+   * ```ts
+   * const enabled = await results.filterAll(u => u.enabled);
+   * ```
+   */
   async filterAll(predicate: (record: T) => boolean): Promise<T[]> {
     const all = await this.getAllRecords();
     return all.filter(predicate);
   }
 
+  /**
+   * Maps all records using the provided transform.
+   * @param transform - Mapping function.
+   * @example
+   * ```ts
+   * const names = await results.mapAll(u => u.name);
+   * ```
+   */
   async mapAll<R>(transform: (record: T) => R): Promise<R[]> {
     const all = await this.getAllRecords();
     return all.map(transform);
   }
 
+  /**
+   * Maximum value produced by the selector across all records.
+   * @param selector - Function extracting a numeric value.
+   * @example
+   * ```ts
+   * const maxAge = await results.maxOfDouble(u => u.age);
+   * ```
+   */
   async maxOfDouble(selector: (record: T) => number): Promise<number> {
     const all = await this.getAllRecords();
     return all.reduce((max, r) => Math.max(max, selector(r)), -Infinity);
   }
 
+  /**
+   * Minimum value produced by the selector across all records.
+   * @param selector - Function extracting a numeric value.
+   * @example
+   * ```ts
+   * const minAge = await results.minOfDouble(u => u.age);
+   * ```
+   */
   async minOfDouble(selector: (record: T) => number): Promise<number> {
     const all = await this.getAllRecords();
     return all.reduce((min, r) => Math.min(min, selector(r)), Infinity);
   }
 
+  /**
+   * Sum of values produced by the selector across all records.
+   * @param selector - Function extracting a numeric value.
+   * @example
+   * ```ts
+   * const total = await results.sumOfDouble(u => u.score);
+   * ```
+   */
   async sumOfDouble(selector: (record: T) => number): Promise<number> {
     const all = await this.getAllRecords();
     return all.reduce((sum, r) => sum + selector(r), 0);
   }
 
+  /**
+   * Maximum float value from the selector.
+   * @param selector - Function extracting a numeric value.
+   */
   async maxOfFloat(selector: (record: T) => number): Promise<number> {
     return this.maxOfDouble(selector);
   }
+  /**
+   * Minimum float value from the selector.
+   * @param selector - Function extracting a numeric value.
+   */
   async minOfFloat(selector: (record: T) => number): Promise<number> {
     return this.minOfDouble(selector);
   }
+  /**
+   * Sum of float values from the selector.
+   * @param selector - Function extracting a numeric value.
+   */
   async sumOfFloat(selector: (record: T) => number): Promise<number> {
     return this.sumOfDouble(selector);
   }
+  /**
+   * Maximum integer value from the selector.
+   * @param selector - Function extracting a numeric value.
+   */
   async maxOfInt(selector: (record: T) => number): Promise<number> {
     return this.maxOfDouble(selector);
   }
+  /**
+   * Minimum integer value from the selector.
+   * @param selector - Function extracting a numeric value.
+   */
   async minOfInt(selector: (record: T) => number): Promise<number> {
     return this.minOfDouble(selector);
   }
+  /**
+   * Sum of integer values from the selector.
+   * @param selector - Function extracting a numeric value.
+   */
   async sumOfInt(selector: (record: T) => number): Promise<number> {
     return this.sumOfDouble(selector);
   }
+  /**
+   * Maximum long value from the selector.
+   * @param selector - Function extracting a numeric value.
+   */
   async maxOfLong(selector: (record: T) => number): Promise<number> {
     return this.maxOfDouble(selector);
   }
+  /**
+   * Minimum long value from the selector.
+   * @param selector - Function extracting a numeric value.
+   */
   async minOfLong(selector: (record: T) => number): Promise<number> {
     return this.minOfDouble(selector);
   }
+  /**
+   * Sum of long values from the selector.
+   * @param selector - Function extracting a numeric value.
+   */
   async sumOfLong(selector: (record: T) => number): Promise<number> {
     return this.sumOfDouble(selector);
   }
 
+  /**
+   * Sum of bigint values from the selector.
+   * @param selector - Function extracting a bigint value.
+   * @example
+   * ```ts
+   * const total = await results.sumOfBigInt(u => u.balance);
+   * ```
+   */
   async sumOfBigInt(selector: (record: T) => bigint): Promise<bigint> {
     const all = await this.getAllRecords();
     return all.reduce((sum, r) => sum + selector(r), 0n);
   }
 
+  /**
+   * Executes an action for each page in parallel.
+   * @param action - Function executed for each record concurrently.
+   * @example
+   * ```ts
+   * await results.forEachPageParallel(async u => sendEmail(u));
+   * ```
+   */
   async forEachPageParallel(action: (item: T) => void | Promise<void>): Promise<void> {
     await this.forEachPage(records => Promise.all(records.map(action)).then(() => true));
   }

--- a/src/types/builders.ts
+++ b/src/types/builders.ts
@@ -3,69 +3,136 @@ import type { Sort, StreamAction } from './common';
 import type { QueryCondition, QueryCriteria } from './protocol';
 import type { QueryResults } from '../builders/query-results';
 
+/**
+ * Builder used to compose query conditions.
+ */
 export interface IConditionBuilder {
+  /**
+   * Combines the current condition with another using `AND`.
+   * @param condition - Additional condition or builder.
+   * @example
+   * ```ts
+   * cb.and({ field: 'age', operator: 'GREATER_THAN', value: 18 });
+   * ```
+   */
   and(condition: IConditionBuilder | QueryCriteria): IConditionBuilder;
+  /**
+   * Combines the current condition with another using `OR`.
+   * @param condition - Additional condition or builder.
+   * @example
+   * ```ts
+   * cb.or({ field: 'status', operator: 'EQUAL', value: 'ACTIVE' });
+   * ```
+   */
   or(condition: IConditionBuilder | QueryCriteria): IConditionBuilder;
+  /**
+   * Materializes the composed condition into a `QueryCondition` object.
+   */
   toCondition(): QueryCondition;
 }
 
+/**
+ * Fluent query builder for constructing and executing select/update/delete operations.
+ */
 export interface IQueryBuilder<T = unknown> {
+  /** Sets the table to query. */
   from(table: string): IQueryBuilder<T>;
+  /** Selects a subset of fields to return. */
   selectFields(fields: string[]): IQueryBuilder<T>;
+  /** Resolves related values by name. */
   resolve(values: string[] | string): IQueryBuilder<T>;
+  /** Adds a filter condition. */
   where(condition: IConditionBuilder | QueryCriteria): IQueryBuilder<T>;
+  /** Adds an additional filter with `AND`. */
   and(condition: IConditionBuilder | QueryCriteria): IQueryBuilder<T>;
+  /** Adds an additional filter with `OR`. */
   or(condition: IConditionBuilder | QueryCriteria): IQueryBuilder<T>;
+  /** Orders results by the provided fields. */
   orderBy(...sorts: Sort[]): IQueryBuilder<T>;
+  /** Groups results by the provided fields. */
   groupBy(...fields: string[]): IQueryBuilder<T>;
+  /** Ensures only distinct records are returned. */
   distinct(): IQueryBuilder<T>;
+  /** Limits the number of records returned. */
   limit(n: number): IQueryBuilder<T>;
+  /** Restricts the query to a specific partition. */
   inPartition(partition: string): IQueryBuilder<T>;
 
+  /** Sets the page size for subsequent `list` or `page` calls. */
   pageSize(n: number): IQueryBuilder<T>;
+  /** Continues a paged query using a next-page token. */
   nextPage(token: string): IQueryBuilder<T>;
 
+  /** Counts matching records. */
   count(): Promise<number>;
+  /** Lists records with optional pagination. */
   list(options?: { pageSize?: number; nextPage?: string }): Promise<QueryResults<T>>;
+  /** Retrieves the first record or null. */
   firstOrNull(): Promise<T | null>;
+  /** Retrieves exactly one record or null. */
   one(): Promise<T | null>;
+  /** Retrieves a single page of records with optional next token. */
   page(options?: { pageSize?: number; nextPage?: string }): Promise<{ records: T[]; nextPage?: string | null }>;
 
+  /** Sets field updates for an update query. */
   setUpdates(updates: Partial<T>): IQueryBuilder<T>;
+  /** Executes an update operation. */
   update(): Promise<unknown>;
+  /** Executes a delete operation. */
   delete(): Promise<unknown>;
 
+  /** Registers a listener for added items on a stream. */
   onItemAdded(listener: (entity: T) => void): IQueryBuilder<T>;
+  /** Registers a listener for updated items on a stream. */
   onItemUpdated(listener: (entity: T) => void): IQueryBuilder<T>;
+  /** Registers a listener for deleted items on a stream. */
   onItemDeleted(listener: (entity: T) => void): IQueryBuilder<T>;
+  /** Registers a listener for any stream item with its action. */
   onItem(listener: (entity: T | null, action: StreamAction) => void): IQueryBuilder<T>;
+  /** Starts a stream including query results. */
   stream(includeQueryResults?: boolean, keepAlive?: boolean): Promise<{ cancel: () => void }>;
+  /** Starts a stream emitting only events. */
   streamEventsOnly(keepAlive?: boolean): Promise<{ cancel: () => void }>;
+  /** Starts a stream that returns events alongside query results. */
   streamWithQueryResults(keepAlive?: boolean): Promise<{ cancel: () => void }>;
 }
 
 export type { QueryResults } from '../builders/query-results';
 
+/** Builder for save operations. */
 export interface ISaveBuilder<T = unknown> {
+  /** Cascades specified relationships when saving. */
   cascade(...relationships: string[]): ISaveBuilder<T>;
+  /** Persists a single entity. */
   one(entity: Partial<T>): Promise<unknown>;
+  /** Persists multiple entities. */
   many(entities: Array<Partial<T>>): Promise<unknown>;
 }
 
+/** Builder for cascading save/delete operations across multiple tables. */
 export interface ICascadeBuilder<Schema = Record<string, unknown>> {
+  /** Specifies relationships to cascade through. */
   cascade(...relationships: string[]): ICascadeBuilder<Schema>;
+  /** Saves one or many entities for a given table. */
   save<Table extends keyof Schema & string>(
     table: Table,
     entityOrEntities: Partial<Schema[Table]> | Array<Partial<Schema[Table]>>
   ): Promise<unknown>;
+  /** Deletes an entity by primary key. */
   delete<Table extends keyof Schema & string>(
     table: Table,
     primaryKey: string,
   ): Promise<Schema[Table]>;
 }
+
+/** Builder for describing cascade relationship metadata. */
 export interface ICascadeRelationshipBuilder {
+  /** Names the relationship graph. */
   graph(name: string): ICascadeRelationshipBuilder;
+  /** Sets the graph type. */
   graphType(type: string): ICascadeRelationshipBuilder;
+  /** Field on the target entity. */
   targetField(field: string): ICascadeRelationshipBuilder;
+  /** Field on the source entity. */
   sourceField(field: string): string;
 }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,12 @@
 // filename: src/types/common.ts
+/**
+ * Supported operators for building query criteria.
+ *
+ * @example
+ * ```ts
+ * const criteria = { field: 'age', operator: 'GREATER_THAN', value: 21 };
+ * ```
+ */
 export type QueryCriteriaOperator =
   | 'EQUAL' | 'NOT_EQUAL' | 'IN' | 'NOT_IN'
   | 'GREATER_THAN' | 'GREATER_THAN_EQUAL'
@@ -11,31 +19,73 @@ export type QueryCriteriaOperator =
   | 'STARTS_WITH' | 'NOT_STARTS_WITH'
   | 'IS_NULL' | 'NOT_NULL';
 
+/** Logical operator used to join conditions in a query. */
 export type LogicalOperator = 'AND' | 'OR';
 
+/**
+ * Sorting instruction for query results.
+ *
+ * @property field - Field name to order by.
+ * @property order - Sort direction.
+ * @example
+ * ```ts
+ * const sort: Sort = { field: 'name', order: 'ASC' };
+ * ```
+ */
 export interface Sort { field: string; order: 'ASC' | 'DESC' }
 
+/** Actions emitted by real-time data streams. */
 export type StreamAction = 'CREATE' | 'UPDATE' | 'DELETE' | 'QUERY_RESPONSE' | 'KEEP_ALIVE';
 
+/**
+ * Basic document representation used by the SDK.
+ *
+ * @example
+ * ```ts
+ * const doc: OnyxDocument = { documentId: '1', content: 'hello' };
+ * ```
+ */
 export interface OnyxDocument {
+  /** Unique document identifier. */
   documentId?: string;
+  /** Path within the Onyx database. */
   path?: string;
+  /** Creation timestamp. */
   created?: Date;
+  /** Last update timestamp. */
   updated?: Date;
+  /** MIME type of the content. */
   mimeType?: string;
+  /** Raw document content. */
   content?: string;
 }
 
 /** Minimal fetch typing to avoid DOM lib dependency */
 export interface FetchResponse {
+  /** Whether the request succeeded (status in the range 200–299). */
   ok: boolean;
+  /** HTTP status code. */
   status: number;
+  /** HTTP status text. */
   statusText: string;
+  /** Response headers getter. */
   headers: { get(name: string): string | null };
+  /** Reads the body as text. */
   text(): Promise<string>;
-  /** raw body for streams; left as unknown to avoid DOM typings */
+  /** Raw body for streams; left as unknown to avoid DOM typings */
   body?: unknown;
 }
+
+/**
+ * Fetch implementation signature used by the SDK.
+ *
+ * @param url - Resource URL.
+ * @param init - Optional init parameters.
+ * @example
+ * ```ts
+ * const res = await fetchImpl('https://api.onyx.dev');
+ * ```
+ */
 export type FetchImpl = (
   url: string,
   init?: { method?: string; headers?: Record<string, string>; body?: string }

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,16 +1,54 @@
 // filename: src/types/protocol.ts
 import type { Sort, LogicalOperator, QueryCriteriaOperator } from './common';
 
+/**
+ * Represents a single field comparison in a query.
+ *
+ * @property field - Field name to evaluate.
+ * @property operator - Comparison operator.
+ * @property value - Value to compare against.
+ * @example
+ * ```ts
+ * const criteria: QueryCriteria = { field: 'age', operator: 'GREATER_THAN', value: 18 };
+ * ```
+ */
 export interface QueryCriteria {
   field: string;
   operator: QueryCriteriaOperator;
   value?: unknown;
 }
 
+/**
+ * Recursive condition structure used to express complex WHERE clauses.
+ *
+ * @example
+ * ```ts
+ * const condition: QueryCondition = {
+ *   conditionType: 'CompoundCondition',
+ *   operator: 'AND',
+ *   conditions: [
+ *     { conditionType: 'SingleCondition', criteria: { field: 'age', operator: 'GREATER_THAN', value: 18 } },
+ *     { conditionType: 'SingleCondition', criteria: { field: 'status', operator: 'EQUAL', value: 'ACTIVE' } }
+ *   ]
+ * };
+ * ```
+ */
 export type QueryCondition =
   | { conditionType: 'SingleCondition'; criteria: QueryCriteria }
   | { conditionType: 'CompoundCondition'; operator: LogicalOperator; conditions: QueryCondition[] };
 
+/**
+ * Wire format for select queries sent to the server.
+ *
+ * @example
+ * ```ts
+ * const query: SelectQuery = {
+ *   type: 'SelectQuery',
+ *   fields: ['id', 'name'],
+ *   limit: 10
+ * };
+ * ```
+ */
 export interface SelectQuery {
   type: 'SelectQuery';
   fields?: string[] | null;
@@ -23,6 +61,17 @@ export interface SelectQuery {
   resolvers?: string[] | null;
 }
 
+/**
+ * Wire format for update queries sent to the server.
+ *
+ * @example
+ * ```ts
+ * const update: UpdateQuery = {
+ *   type: 'UpdateQuery',
+ *   updates: { name: 'New Name' }
+ * };
+ * ```
+ */
 export interface UpdateQuery {
   type: 'UpdateQuery';
   conditions?: QueryCondition | null;
@@ -32,7 +81,17 @@ export interface UpdateQuery {
   partition?: string | null;
 }
 
+/**
+ * A single page of query results.
+ *
+ * @example
+ * ```ts
+ * const page: QueryPage<User> = { records: users, nextPage: token };
+ * ```
+ */
 export interface QueryPage<T> {
+  /** Records in the current page. */
   records: T[];
+  /** Token for the next page or null if none. */
   nextPage?: string | null;
 }


### PR DESCRIPTION
## Summary
- add JSDoc comments with parameter documentation and examples for core query types
- document QueryResults utilities
- expand builder interfaces with examples and parameter docs

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b90273146c8321af5bdfd85f5988de