### PR TITLE
feat: add values helper to QueryResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ const allActive = await db
   .from('User')
   .where(eq('status', 'active'))
   .list();
+
+// Collect IDs across all pages
+const ids = await db.from('User').list().values('id');
 ```
 
 ### 1b) First or null

--- a/changelog/2025-09-07-0900am-query-results-values.md
+++ b/changelog/2025-09-07-0900am-query-results-values.md
@@ -1,0 +1,14 @@
+# Change: add values() to QueryResults
+
+- Date: 2025-09-07 09:00 AM PT
+- Author/Agent: openai
+- Scope: lib
+- Type: feat
+- Summary:
+  - allow QueryResults to extract field values across all pages
+  - document values helper in README
+- Impact:
+  - expands public API
+- Follow-ups:
+  - none
+

--- a/codex/tasks/library-readiness/finished/021-query-results-values.md
+++ b/codex/tasks/library-readiness/finished/021-query-results-values.md
@@ -1,0 +1,17 @@
+# 021 QueryResults values helper
+
+## Task
+Add a `values(field)` method to `QueryResults` that returns an array of the specified field across all pages.
+
+## Plan
+1. Implement `values` in `src/builders/query-results.ts` to gather all pages and pluck the field.
+2. Add unit test verifying `values` collects IDs across multiple pages.
+3. Document the helper in the README.
+4. Record a changelog entry.
+
+## Acceptance Criteria
+- [x] `QueryResults.values` fetches every page and returns field values.
+- [x] Test coverage ensures the method works.
+- [x] README shows usage of `values`.
+- [x] Changelog entry added.
+

--- a/docs/interfaces/QueryResults.md
+++ b/docs/interfaces/QueryResults.md
@@ -21,3 +21,23 @@ Defined in: types/builders.ts:5
 > `optional` **nextPage**: `null` | `string`
 
 Defined in: types/builders.ts:6
+
+## Methods
+
+### values()
+
+> **values**(`field`): `Promise`<`T`[`K`][]>
+
+Collects all pages and returns the values for the specified field.
+
+#### Parameters
+
+##### field
+
+`K`
+
+#### Returns
+
+`Promise`<`T`[`K`][]> 
+
+Defined in: builders/query-results.ts:186

--- a/src/builders/query-results.ts
+++ b/src/builders/query-results.ts
@@ -176,6 +176,20 @@ export class QueryResults<T> extends Array<T> {
   }
 
   /**
+   * Extracts values for a field across all records.
+   * @param field - Name of the field to pluck.
+   * @example
+   * ```ts
+   * const ids = await results.values('id');
+   * ```
+   */
+  // @ts-expect-error overriding Array#values
+  async values<K extends keyof T>(field: K): Promise<Array<T[K]>> {
+    const all = await this.getAllRecords();
+    return all.map(r => r[field]);
+  }
+
+  /**
    * Maximum value produced by the selector across all records.
    * @param selector - Function extracting a numeric value.
    * @example

--- a/tests/query-results.spec.ts
+++ b/tests/query-results.spec.ts
@@ -51,6 +51,9 @@ describe('QueryResults', () => {
     const mapped = await res.mapAll(r => r.id);
     expect(mapped).toEqual([1, 2, 3]);
 
+    const idsViaValues = await res.values('id');
+    expect(idsViaValues).toEqual([1, 2, 3]);
+
     expect(await res.maxOfInt(r => r.id)).toBe(3);
     expect(await res.sumOfInt(r => r.id)).toBe(6);
     expect(await res.minOfInt(r => r.id)).toBe(1);


### PR DESCRIPTION
## Summary
- allow plucking field values from paginated results via `QueryResults.values`
- document `values` usage in README and API docs
- record codex task and changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b907befdc08321bfa555728b0edef5