### PR TITLE
feat: expose QueryResults helpers on promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ const allActive = await db
 
 // Collect IDs across all pages
 const ids = await db.from('User').list().values('id');
+// Get the first user across pages
+const firstUser = await db.from('User').list().firstOrNull();
+// Call any QueryResults helper before awaiting
+const size = await db.from('User').list().size();
 ```
 
 ### 1b) First or null

--- a/changelog/2025-09-03-0918pm-query-results-promise-first-or-null.md
+++ b/changelog/2025-09-03-0918pm-query-results-promise-first-or-null.md
@@ -1,0 +1,12 @@
+# Change: expose QueryResults helpers on QueryResultsPromise
+
+- Date: 2025-09-03 09:18 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: feat
+- Summary:
+  - allow QueryResultsPromise to call all QueryResults helper methods directly
+- Impact:
+  - enables chaining helpers like `size()` or `firstOrNull()` before awaiting
+- Follow-ups:
+  - none

--- a/src/builders/query-builder.ts
+++ b/src/builders/query-builder.ts
@@ -481,7 +481,10 @@ export class QueryBuilder<T = unknown> implements IQueryBuilder<T> {
       const fetcher = (token: string) => this.nextPage(token).list({ pageSize: size });
       return new QueryResults<T>(Array.isArray(pg.records) ? pg.records : [], pg.nextPage ?? null, fetcher);
     });
-    (pgPromise as QueryResultsPromise<T>).values = field => pgPromise.then(res => res.values(field));
+    for (const m of Object.getOwnPropertyNames(QueryResults.prototype) as string[]) {
+      if (m === 'constructor') continue;
+      (pgPromise as any)[m] = (...args: any[]) => pgPromise.then(res => (res as any)[m](...args));
+    }
     return pgPromise as QueryResultsPromise<T>;
   }
 

--- a/src/builders/query-results.ts
+++ b/src/builders/query-results.ts
@@ -9,7 +9,8 @@
  * ```
  */
 export type QueryResultsPromise<T> = Promise<QueryResults<T>> & {
-  values<K extends keyof T>(field: K): Promise<Array<T[K]>>;
+  [K in keyof QueryResults<T> as QueryResults<T>[K] extends (...args: any[]) => any ? K : never]:
+    QueryResults<T>[K] extends (...args: infer P) => infer R ? (...args: P) => Promise<Awaited<R>> : never;
 };
 
 export class QueryResults<T> extends Array<T> {

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -548,7 +548,10 @@ class QueryBuilderImpl<T = unknown, S = Record<string, unknown>> implements IQue
       const fetcher = (token: string) => this.nextPage(token).list({ pageSize: size });
       return new QueryResults<T>(Array.isArray(pg.records) ? pg.records : [], pg.nextPage ?? null, fetcher);
     });
-    (pgPromise as QueryResultsPromise<T>).values = field => pgPromise.then(res => res.values(field));
+    for (const m of Object.getOwnPropertyNames(QueryResults.prototype) as string[]) {
+      if (m === 'constructor') continue;
+      (pgPromise as any)[m] = (...args: any[]) => pgPromise.then(res => (res as any)[m](...args));
+    }
     return pgPromise as QueryResultsPromise<T>;
   }
 

--- a/tests/query-results.spec.ts
+++ b/tests/query-results.spec.ts
@@ -58,6 +58,14 @@ describe('QueryResults', () => {
     const idsDirect = await qb2.list().values('id');
     expect(idsDirect).toEqual([1, 2, 3]);
 
+    const qb3 = new QueryBuilder(exec as any, 'users');
+    const firstDirect = await qb3.list().firstOrNull();
+    expect(firstDirect).toEqual({ id: 1 });
+
+    const qb4 = new QueryBuilder(exec as any, 'users');
+    const sizeDirect = await qb4.list().size();
+    expect(sizeDirect).toBe(2);
+
     expect(await res.maxOfInt(r => r.id)).toBe(3);
     expect(await res.sumOfInt(r => r.id)).toBe(6);
     expect(await res.minOfInt(r => r.id)).toBe(1);


### PR DESCRIPTION
## Summary
- proxy all `QueryResults` helper methods onto `QueryResultsPromise`
- reflectively attach helpers so `list()` results support chaining before await
- document and test calling helpers like `size()` directly on `list()`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b912839cd083218f09af981fd8af18