### PR TITLE
feat: allow inOp to accept comma-delimited strings

### DIFF
--- a/changelog/2025-09-03-0950pm-inop-string-support.md
+++ b/changelog/2025-09-03-0950pm-inop-string-support.md
@@ -1,0 +1,13 @@
+# Change: allow inOp to accept comma-delimited strings
+
+- Date: 2025-09-03 09:50 PM PT
+- Author/Agent: OpenAI Assistant
+- Scope: lib
+- Type: feat
+- Summary:
+  - allow `inOp` to accept a comma-delimited string or array
+  - document and test string support
+- Impact:
+  - expands condition helper without breaking existing API
+- Follow-ups:
+  - none

--- a/docs/functions/inOp.md
+++ b/docs/functions/inOp.md
@@ -18,7 +18,7 @@ Defined in: helpers/conditions.ts:11
 
 ### values
 
-`unknown`[]
+`string` | `unknown`[]
 
 ## Returns
 

--- a/src/helpers/conditions.ts
+++ b/src/helpers/conditions.ts
@@ -8,7 +8,14 @@ const c = (field: string, operator: QueryCriteriaOperator, value?: unknown) =>
 
 export const eq = (field: string, value: unknown) => c(field, 'EQUAL', value);
 export const neq = (field: string, value: unknown) => c(field, 'NOT_EQUAL', value);
-export const inOp = (field: string, values: unknown[]) => c(field, 'IN', values);
+export const inOp = (field: string, values: unknown[] | string) =>
+  c(
+    field,
+    'IN',
+    typeof values === 'string'
+      ? values.split(',').map((v) => v.trim()).filter((v) => v.length)
+      : values,
+  );
 export const notIn = (field: string, values: unknown[]) => c(field, 'NOT_IN', values);
 export const between = (field: string, lower: unknown, upper: unknown) => c(field, 'BETWEEN', [lower, upper]);
 export const gt = (field: string, value: unknown) => c(field, 'GREATER_THAN', value);

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -25,7 +25,8 @@ describe('helper utilities', () => {
     // Execute every helper to ensure complete coverage
     cond.eq('a', 1).toCondition();
     cond.neq('a', 1);
-    cond.inOp('a', [1]);
+    expect(cond.inOp('a', [1, 2]).toCondition().criteria.value).toEqual([1, 2]);
+    expect(cond.inOp('a', 'b,c').toCondition().criteria.value).toEqual(['b', 'c']);
     cond.notIn('a', [1]);
     cond.between('a', 1, 2);
     cond.gt('a', 1);


### PR DESCRIPTION
## Summary
- allow `inOp` to accept a comma-delimited string or array
- document and test string support for `inOp`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run docs`


------
https://chatgpt.com/codex/tasks/task_e_68b91a70838883219f5420344889eb05