### PR TITLE
feat: add response logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ const db = onyx.init({
   apiKey: 'YOUR_KEY',
   apiSecret: 'YOUR_SECRET',
   requestLoggingEnabled: true, // logs HTTP requests
+  responseLoggingEnabled: true, // logs HTTP responses
 });
 ```
 
-Enable `requestLoggingEnabled` to log each request and its body to the console.
+Enable `requestLoggingEnabled` to log each request and its body to the console. Enable `responseLoggingEnabled` to log responses and bodies.
 
 ### Option C) Node-only config files
 

--- a/changelog/2025-09-03-1143pm-response-logging.md
+++ b/changelog/2025-09-03-1143pm-response-logging.md
@@ -1,0 +1,12 @@
+# Change: add response logging option
+
+- Date: 2025-09-03 11:43 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: feat
+- Summary:
+  - add `responseLoggingEnabled` option to log HTTP responses and bodies
+- Impact:
+  - optional debugging output; no breaking changes
+- Follow-ups:
+  - none

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -19,6 +19,7 @@ export interface HttpClientOptions {
   fetchImpl?: FetchImpl;
   defaultHeaders?: Record<string, string>;
   requestLoggingEnabled?: boolean;
+  responseLoggingEnabled?: boolean;
 }
 
 export class HttpClient {
@@ -28,6 +29,7 @@ export class HttpClient {
   private readonly fetchImpl: FetchImpl;
   private readonly defaults: Record<string, string>;
   private readonly requestLoggingEnabled: boolean;
+  private readonly responseLoggingEnabled: boolean;
 
   constructor(opts: HttpClientOptions) {
     if (!opts.baseUrl || opts.baseUrl.trim() === '') {
@@ -52,6 +54,7 @@ export class HttpClient {
     }
     this.defaults = Object.assign({}, opts.defaultHeaders);
     this.requestLoggingEnabled = !!opts.requestLoggingEnabled;
+    this.responseLoggingEnabled = !!opts.responseLoggingEnabled;
   }
 
   headers(extra?: Record<string, string>): Record<string, string> {
@@ -104,6 +107,13 @@ export class HttpClient {
         const res = await this.fetchImpl(url, init);
         const contentType = res.headers.get('Content-Type') || '';
         const raw = await res.text();
+        if (this.responseLoggingEnabled) {
+          const statusLine = `${res.status} ${res.statusText}`.trim();
+          console.log(statusLine);
+          if (raw.trim().length > 0) {
+            console.log(raw);
+          }
+        }
         const isJson =
           raw.trim().length > 0 &&
           (contentType.includes('application/json') || /^[\[{]/.test(raw.trim()));

--- a/src/impl/onyx.ts
+++ b/src/impl/onyx.ts
@@ -34,9 +34,10 @@ function resolveConfigWithCache(config?: OnyxConfig): Promise<ResolvedConfig> {
   if (cachedCfg && cachedCfg.expires > now) {
     return cachedCfg.promise;
   }
-  const { ttl: _ttl, requestLoggingEnabled: _reqLog, ...rest } = config ?? {};
+  const { ttl: _ttl, requestLoggingEnabled: _reqLog, responseLoggingEnabled: _resLog, ...rest } = config ?? {};
   void _ttl;
   void _reqLog;
+  void _resLog;
   const promise = resolveConfig(rest);
   cachedCfg = { promise, expires: now + ttl };
   return promise;
@@ -86,10 +87,12 @@ class OnyxDatabaseImpl<Schema = Record<string, unknown>> implements IOnyxDatabas
   private http: HttpClient | null = null;
   private readonly streams = new Set<{ cancel: () => void }>();
   private readonly requestLoggingEnabled: boolean;
+  private readonly responseLoggingEnabled: boolean;
 
   constructor(config?: OnyxConfig) {
     // Defer resolution; keeps init() synchronous
     this.requestLoggingEnabled = !!config?.requestLoggingEnabled;
+    this.responseLoggingEnabled = !!config?.responseLoggingEnabled;
     this.cfgPromise = resolveConfigWithCache(config);
   }
 
@@ -109,6 +112,7 @@ class OnyxDatabaseImpl<Schema = Record<string, unknown>> implements IOnyxDatabas
         apiSecret: this.resolved.apiSecret,
         fetchImpl: this.resolved.fetch,
         requestLoggingEnabled: this.requestLoggingEnabled,
+        responseLoggingEnabled: this.responseLoggingEnabled,
       });
     }
     return {

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -22,6 +22,10 @@ export interface OnyxConfig {
    */
   requestLoggingEnabled?: boolean;
   /**
+   * When true, log HTTP responses and bodies to the console.
+   */
+  responseLoggingEnabled?: boolean;
+  /**
    * Milliseconds to cache resolved credentials; defaults to 5 minutes.
    */
   ttl?: number;

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -131,6 +131,48 @@ describe('HttpClient', () => {
     logSpy.mockRestore();
   });
 
+  it('logs responses and bodies when responseLoggingEnabled', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const client = new HttpClient({
+      baseUrl: base,
+      ...creds,
+      fetchImpl: fetchMock,
+      responseLoggingEnabled: true,
+    });
+    await client.request('GET', '/resp');
+    expect(logSpy).toHaveBeenNthCalledWith(1, '200 OK');
+    expect(logSpy).toHaveBeenNthCalledWith(2, JSON.stringify({ ok: true }));
+    logSpy.mockRestore();
+  });
+
+  it('logs response line without body when enabled and body absent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 204,
+        statusText: 'No Content',
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const client = new HttpClient({
+      baseUrl: base,
+      ...creds,
+      fetchImpl: fetchMock,
+      responseLoggingEnabled: true,
+    });
+    await client.request('GET', '/no-content');
+    expect(logSpy).toHaveBeenCalledWith('204 No Content');
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    logSpy.mockRestore();
+  });
+
   it('omits Content-Type on body-less DELETE and parses JSON', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {


### PR DESCRIPTION
## Summary
- add `responseLoggingEnabled` configuration
- log HTTP response details when enabled
- document and test response logging behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b934dc9e3c832181f99aa24b1b6953