### PR TITLE
feat: allow logging via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ const db = onyx.init({
 
 Enable `requestLoggingEnabled` to log each request and its body to the console. Enable `responseLoggingEnabled` to log responses and bodies.
 
+You can also enable logging globally via environment variables when config options are omitted:
+
+```bash
+export ONYX_REQUEST_LOGGING_ENABLED=1
+export ONYX_RESPONSE_LOGGING_ENABLED=1
+```
+
+Values of `1` or `true` (case-insensitive) turn on the corresponding logging mode.
+
 ### Option C) Node-only config files
 
 When running on Node.js, the resolver also checks for JSON files matching the `OnyxConfig` shape in the following order:

--- a/changelog/2025-09-04-0718am-env-logging-config.md
+++ b/changelog/2025-09-04-0718am-env-logging-config.md
@@ -1,0 +1,13 @@
+# Change: env vars for request/response logging
+
+- Date: 2025-09-04 12:18 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: feat
+- Summary:
+  - allow enabling request and response logging via `ONYX_REQUEST_LOGGING_ENABLED` and `ONYX_RESPONSE_LOGGING_ENABLED`
+  - use env values when config options are omitted and cache them with other resolved config
+- Impact:
+  - new environment variable configuration for logging
+- Follow-ups:
+  - none

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,8 @@ const db = onyx.init({
 });
 ```
 
+Enable `requestLoggingEnabled` to log each request and its body to the console. Enable `responseLoggingEnabled` to log responses and bodies. You can also enable these globally via the `ONYX_REQUEST_LOGGING_ENABLED` and `ONYX_RESPONSE_LOGGING_ENABLED` environment variables when the options are omitted (values of `1` or `true`).
+
 ### Connection handling
 
 Calling `onyx.init()` returns a lightweight client. Configuration is resolved once

--- a/tests/logging-env.spec.ts
+++ b/tests/logging-env.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { onyx } from '../src';
+
+describe('logging via env vars', () => {
+  afterEach(() => {
+    delete process.env.ONYX_REQUEST_LOGGING_ENABLED;
+    delete process.env.ONYX_RESPONSE_LOGGING_ENABLED;
+    onyx.clearCacheConfig();
+  });
+
+  it('enables request logging from env', async () => {
+    process.env.ONYX_REQUEST_LOGGING_ENABLED = '1';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { message: 'not found' } }),
+        {
+          status: 404,
+          statusText: 'Not Found',
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const db = onyx.init({
+      baseUrl: 'https://api.test',
+      databaseId: 'db',
+      apiKey: 'k',
+      apiSecret: 's',
+      fetch: fetchMock,
+    });
+    await db.findById('User', '1');
+    expect(logSpy).toHaveBeenCalledWith('GET https://api.test/data/db/User/1');
+    logSpy.mockRestore();
+  });
+
+  it('enables response logging from env', async () => {
+    process.env.ONYX_RESPONSE_LOGGING_ENABLED = 'true';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const db = onyx.init({
+      baseUrl: 'https://api.test',
+      databaseId: 'db',
+      apiKey: 'k',
+      apiSecret: 's',
+      fetch: fetchMock,
+    });
+    await db.getDocument('doc1');
+    expect(logSpy).toHaveBeenCalledWith('200 OK');
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- allow enabling request/response logging via ONYX_REQUEST_LOGGING_ENABLED and ONYX_RESPONSE_LOGGING_ENABLED
- document env-based logging options
- add tests for env-driven logging

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93ccac2048321b6ee010298f815cb