### PR TITLE
docs: add builder and database usage examples

### DIFF
--- a/changelog/2025-09-04-0122pm-builder-interface-examples.md
+++ b/changelog/2025-09-04-0122pm-builder-interface-examples.md
@@ -1,0 +1,13 @@
+# Change: expand builder and database interface examples
+
+- Date: 2025-09-04 01:22 PM PT
+- Author/Agent: ChatGPT
+- Scope: docs
+- Type: docs
+- Summary:
+  - add usage examples to IOnyxDatabase methods
+  - document common patterns on builder interfaces
+- Impact:
+  - improves generated API documentation
+- Follow-ups:
+  - none

--- a/changelog/2025-09-04-0155pm-order-partition-examples.md
+++ b/changelog/2025-09-04-0155pm-order-partition-examples.md
@@ -1,0 +1,13 @@
+# Change: add query order and partition examples
+
+- Date: 2025-09-04 01:55 PM PT
+- Author/Agent: Codex
+- Scope: examples
+- Type: docs
+- Summary:
+  - add query builder examples for ordering and partitions
+  - correct orderBy docs to reference asc helper
+- Impact:
+  - improves developer guidance with no runtime changes
+- Follow-ups:
+  - none

--- a/examples/query/in-partition.ts
+++ b/examples/query/in-partition.ts
@@ -1,0 +1,28 @@
+// filename: examples/query/in-partition.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+import { tables, Schema } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const tenantUsers = await db
+    .from(tables.User)
+    .inPartition('tenantA')
+    .list();
+
+  console.log(JSON.stringify(tenantUsers, null, 2));
+  /*
+    [
+      {
+        "id": "tenantA-user-1",
+        "email": "a@example.com"
+      }
+    ]
+  */
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/query/order-by.ts
+++ b/examples/query/order-by.ts
@@ -1,0 +1,30 @@
+// filename: examples/query/order-by.ts
+import process from 'node:process';
+import { onyx, desc } from '@onyx.dev/onyx-database';
+import { tables, Schema } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const users = await db
+    .from(tables.User)
+    .orderBy(desc('createdAt'))
+    .limit(3)
+    .list();
+
+  console.log(JSON.stringify(users, null, 2));
+  /*
+    [
+      {
+        "id": "example-user-1",
+        "email": "basic@example.com",
+        "createdAt": "2025-08-26T19:47:29.000Z"
+      }
+    ]
+  */
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/types/builders.ts
+++ b/src/types/builders.ts
@@ -27,6 +27,10 @@ export interface IConditionBuilder {
   or(condition: IConditionBuilder | QueryCriteria): IConditionBuilder;
   /**
    * Materializes the composed condition into a `QueryCondition` object.
+   * @example
+   * ```ts
+   * const cond = cb.toCondition();
+   * ```
    */
   toCondition(): QueryCondition;
 }
@@ -35,65 +39,237 @@ export interface IConditionBuilder {
  * Fluent query builder for constructing and executing select/update/delete operations.
  */
 export interface IQueryBuilder<T = unknown> {
-  /** Sets the table to query. */
+  /**
+   * Sets the table to query.
+   * @example
+   * ```ts
+   * const users = await db.from('User').list();
+   * ```
+   */
   from(table: string): IQueryBuilder<T>;
-  /** Selects a subset of fields to return. */
+  /**
+   * Selects a subset of fields to return.
+   * @example
+   * ```ts
+   * const emails = await db.from('User').selectFields(['email']).list();
+   * ```
+   */
   selectFields(fields: string[]): IQueryBuilder<T>;
-  /** Resolves related values by name. */
+  /**
+   * Resolves related values by name.
+   * @example
+   * ```ts
+   * const users = await db
+   *   .from('User')
+   *   .resolve('profile')
+   *   .list();
+   * ```
+   */
   resolve(values: string[] | string): IQueryBuilder<T>;
-  /** Adds a filter condition. */
+  /**
+   * Adds a filter condition.
+   * @example
+   * ```ts
+   * const active = await db.from('User').where(eq('status', 'active')).list();
+   * ```
+   */
   where(condition: IConditionBuilder | QueryCriteria): IQueryBuilder<T>;
-  /** Adds an additional filter with `AND`. */
+  /**
+   * Adds an additional filter with `AND`.
+   * @example
+   * ```ts
+   * qb.where(eq('status', 'active')).and(eq('role', 'admin'));
+   * ```
+   */
   and(condition: IConditionBuilder | QueryCriteria): IQueryBuilder<T>;
-  /** Adds an additional filter with `OR`. */
+  /**
+   * Adds an additional filter with `OR`.
+   * @example
+   * ```ts
+   * qb.where(eq('status', 'active')).or(eq('status', 'invited'));
+   * ```
+   */
   or(condition: IConditionBuilder | QueryCriteria): IQueryBuilder<T>;
-  /** Orders results by the provided fields. */
+  /**
+   * Orders results by the provided fields.
+   * @example
+   * ```ts
+   * const users = await db.from('User').orderBy(asc('createdAt')).list();
+   * ```
+   */
   orderBy(...sorts: Sort[]): IQueryBuilder<T>;
-  /** Groups results by the provided fields. */
+  /**
+   * Groups results by the provided fields.
+   * @example
+   * ```ts
+   * const stats = await db.from('User').groupBy('status').list();
+   * ```
+   */
   groupBy(...fields: string[]): IQueryBuilder<T>;
-  /** Ensures only distinct records are returned. */
+  /**
+   * Ensures only distinct records are returned.
+   * @example
+   * ```ts
+   * const roles = await db.from('User').selectFields(['role']).distinct().list();
+   * ```
+   */
   distinct(): IQueryBuilder<T>;
-  /** Limits the number of records returned. */
+  /**
+   * Limits the number of records returned.
+   * @example
+   * ```ts
+   * const few = await db.from('User').limit(5).list();
+   * ```
+   */
   limit(n: number): IQueryBuilder<T>;
-  /** Restricts the query to a specific partition. */
+  /**
+   * Restricts the query to a specific partition.
+   * @example
+   * ```ts
+   * const tenantUsers = await db.from('User').inPartition('tenantA').list();
+   * ```
+   */
   inPartition(partition: string): IQueryBuilder<T>;
 
   /** Sets the page size for subsequent `list` or `page` calls. */
   pageSize(n: number): IQueryBuilder<T>;
-  /** Continues a paged query using a next-page token. */
+  /**
+   * Continues a paged query using a next-page token.
+   * @example
+   * ```ts
+   * const page2 = await db.from('User').nextPage(token).list();
+   * ```
+   */
   nextPage(token: string): IQueryBuilder<T>;
 
-  /** Counts matching records. */
+  /**
+   * Counts matching records.
+   * @example
+   * ```ts
+   * const total = await db.from('User').count();
+   * ```
+   */
   count(): Promise<number>;
-  /** Lists records with optional pagination. */
+  /**
+   * Lists records with optional pagination.
+   * @example
+   * ```ts
+   * const users = await db.from('User').list({ pageSize: 10 });
+   * ```
+   */
   list(options?: { pageSize?: number; nextPage?: string }): QueryResultsPromise<T>;
-  /** Retrieves the first record or null. */
+  /**
+   * Retrieves the first record or null.
+   * @example
+   * ```ts
+   * const user = await db.from('User').firstOrNull();
+   * ```
+   */
   firstOrNull(): Promise<T | null>;
-  /** Retrieves exactly one record or null. */
+  /**
+   * Retrieves exactly one record or null.
+   * @example
+   * ```ts
+   * const user = await db
+   *   .from('User')
+   *   .where(eq('email', 'a@b.com'))
+   *   .one();
+   * ```
+   */
   one(): Promise<T | null>;
-  /** Retrieves a single page of records with optional next token. */
+  /**
+   * Retrieves a single page of records with optional next token.
+   * @example
+   * ```ts
+   * const { records, nextPage } = await db.from('User').page({ pageSize: 25 });
+   * ```
+   */
   page(options?: { pageSize?: number; nextPage?: string }): Promise<{ records: T[]; nextPage?: string | null }>;
 
-  /** Sets field updates for an update query. */
+  /**
+   * Sets field updates for an update query.
+   * @example
+   * ```ts
+   * await db
+   *   .from('User')
+   *   .where(eq('id', 'u1'))
+   *   .setUpdates({ status: 'active' })
+   *   .update();
+   * ```
+   */
   setUpdates(updates: Partial<T>): IQueryBuilder<T>;
-  /** Executes an update operation. */
+  /**
+   * Executes an update operation.
+   * @example
+   * ```ts
+   * await db.from('User').where(eq('id', 'u1')).setUpdates({ status: 'active' }).update();
+   * ```
+   */
   update(): Promise<unknown>;
-  /** Executes a delete operation. */
+  /**
+   * Executes a delete operation.
+   * @example
+   * ```ts
+   * await db.from('User').where(eq('status', 'inactive')).delete();
+   * ```
+   */
   delete(): Promise<unknown>;
 
-  /** Registers a listener for added items on a stream. */
+  /**
+   * Registers a listener for added items on a stream.
+   * @example
+   * ```ts
+   * db.from('User').onItemAdded(u => console.log('added', u));
+   * ```
+   */
   onItemAdded(listener: (entity: T) => void): IQueryBuilder<T>;
-  /** Registers a listener for updated items on a stream. */
+  /**
+   * Registers a listener for updated items on a stream.
+   * @example
+   * ```ts
+   * db.from('User').onItemUpdated(u => console.log('updated', u));
+   * ```
+   */
   onItemUpdated(listener: (entity: T) => void): IQueryBuilder<T>;
-  /** Registers a listener for deleted items on a stream. */
+  /**
+   * Registers a listener for deleted items on a stream.
+   * @example
+   * ```ts
+   * db.from('User').onItemDeleted(u => console.log('deleted', u));
+   * ```
+   */
   onItemDeleted(listener: (entity: T) => void): IQueryBuilder<T>;
-  /** Registers a listener for any stream item with its action. */
+  /**
+   * Registers a listener for any stream item with its action.
+   * @example
+   * ```ts
+   * db.from('User').onItem((u, action) => console.log(action, u));
+   * ```
+   */
   onItem(listener: (entity: T | null, action: StreamAction) => void): IQueryBuilder<T>;
-  /** Starts a stream including query results. */
+  /**
+   * Starts a stream including query results.
+   * @example
+   * ```ts
+   * const { cancel } = await db.from('User').stream();
+   * ```
+   */
   stream(includeQueryResults?: boolean, keepAlive?: boolean): Promise<{ cancel: () => void }>;
-  /** Starts a stream emitting only events. */
+  /**
+   * Starts a stream emitting only events.
+   * @example
+   * ```ts
+   * const { cancel } = await db.from('User').streamEventsOnly();
+   * ```
+   */
   streamEventsOnly(keepAlive?: boolean): Promise<{ cancel: () => void }>;
-  /** Starts a stream that returns events alongside query results. */
+  /**
+   * Starts a stream that returns events alongside query results.
+   * @example
+   * ```ts
+   * const { cancel } = await db.from('User').streamWithQueryResults();
+   * ```
+   */
   streamWithQueryResults(keepAlive?: boolean): Promise<{ cancel: () => void }>;
 }
 
@@ -101,24 +277,60 @@ export type { QueryResults, QueryResultsPromise } from '../builders/query-result
 
 /** Builder for save operations. */
 export interface ISaveBuilder<T = unknown> {
-  /** Cascades specified relationships when saving. */
+  /**
+   * Cascades specified relationships when saving.
+   * @example
+   * ```ts
+   * await db.save('User').cascade('role').one(user);
+   * ```
+   */
   cascade(...relationships: string[]): ISaveBuilder<T>;
-  /** Persists a single entity. */
+  /**
+   * Persists a single entity.
+   * @example
+   * ```ts
+   * await db.save('User').one({ id: 'u1' });
+   * ```
+   */
   one(entity: Partial<T>): Promise<unknown>;
-  /** Persists multiple entities. */
+  /**
+   * Persists multiple entities.
+   * @example
+   * ```ts
+   * await db.save('User').many([{ id: 'u1' }, { id: 'u2' }]);
+   * ```
+   */
   many(entities: Array<Partial<T>>): Promise<unknown>;
 }
 
 /** Builder for cascading save/delete operations across multiple tables. */
 export interface ICascadeBuilder<Schema = Record<string, unknown>> {
-  /** Specifies relationships to cascade through. */
+  /**
+   * Specifies relationships to cascade through.
+   * @example
+   * ```ts
+   * const builder = db.cascade('permissions');
+   * ```
+   */
   cascade(...relationships: string[]): ICascadeBuilder<Schema>;
-  /** Saves one or many entities for a given table. */
+  /**
+   * Saves one or many entities for a given table.
+   * @example
+   * ```ts
+   * await db.cascade('permissions').save('Role', role);
+   * ```
+   */
   save<Table extends keyof Schema & string>(
     table: Table,
     entityOrEntities: Partial<Schema[Table]> | Array<Partial<Schema[Table]>>
   ): Promise<unknown>;
-  /** Deletes an entity by primary key. */
+  /**
+   * Deletes an entity by primary key.
+   * @example
+   * ```ts
+   * await db.cascade('permissions').delete('Role', 'admin');
+   * ```
+   */
   delete<Table extends keyof Schema & string>(
     table: Table,
     primaryKey: string,
@@ -127,12 +339,36 @@ export interface ICascadeBuilder<Schema = Record<string, unknown>> {
 
 /** Builder for describing cascade relationship metadata. */
 export interface ICascadeRelationshipBuilder {
-  /** Names the relationship graph. */
+  /**
+   * Names the relationship graph.
+   * @example
+   * ```ts
+   * builder.graph('permissions');
+   * ```
+   */
   graph(name: string): ICascadeRelationshipBuilder;
-  /** Sets the graph type. */
+  /**
+   * Sets the graph type.
+   * @example
+   * ```ts
+   * builder.graphType('Permission');
+   * ```
+   */
   graphType(type: string): ICascadeRelationshipBuilder;
-  /** Field on the target entity. */
+  /**
+   * Field on the target entity.
+   * @example
+   * ```ts
+   * builder.targetField('roleId');
+   * ```
+   */
   targetField(field: string): ICascadeRelationshipBuilder;
-  /** Field on the source entity. */
+  /**
+   * Field on the source entity.
+   * @example
+   * ```ts
+   * const rel = builder.sourceField('id');
+   * ```
+   */
   sourceField(field: string): string;
 }

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -252,10 +252,18 @@ export interface IOnyxDatabase<Schema = Record<string, unknown>> {
    * ```
    *
    * @param documentId ID of the document to delete.
-   */
+  */
   deleteDocument(documentId: string): Promise<unknown>;
 
-  /** Cancels active streams; safe to call multiple times */
+  /**
+   * Cancels active streams; safe to call multiple times.
+   * @example
+   * ```ts
+   * const stream = await db.from('User').stream();
+   * stream.cancel();
+   * db.close();
+   * ```
+   */
   close(): void;
 }
 


### PR DESCRIPTION
## Summary
- document stream closing in `IOnyxDatabase.close`
- add usage snippets to `IQueryBuilder`, `ISaveBuilder`, and cascade builder interfaces
- add query examples for ordering and partitions
- fix `orderBy` docs to reference `asc` helper

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run docs`
- `cd examples && npm run gen:onyx`
- `cd examples && npm start` *(fails: Missing script "start")*


------
https://chatgpt.com/codex/tasks/task_e_68b9f42a4b388321a8cf6b1777931a79