### PR TITLE
refactor: refine retry policy

### DIFF
--- a/changelog/2025-09-04-1008pm-retry-policy.md
+++ b/changelog/2025-09-04-1008pm-retry-policy.md
@@ -1,0 +1,14 @@
+# Change: refine retry policy
+
+- Date: 2025-09-04 10:08 PM UTC
+- Author/Agent: AI
+- Scope: lib
+- Type: refactor
+- Summary:
+  - limit retries to GET and read query requests
+  - apply exponential backoff strategy
+  - skip retries for create, update, save, and delete operations
+- Impact:
+  public API unchanged, behavior adjusted for reliability
+- Follow-ups:
+  none

--- a/codex/tasks/library-readiness/finished/013-retry-policy.md
+++ b/codex/tasks/library-readiness/finished/013-retry-policy.md
@@ -1,0 +1,14 @@
+# Task: Restrict retries to queries and gets
+
+## Task
+Remove retry logic for create, update, save, and delete requests. Implement exponential backoff retries for query and get requests only.
+
+## Plan
+1. Update `src/core/http.ts` to only retry when the request is a `GET` or a read query (`/query/` not including update/delete) and to use exponential backoff (`base * 2^attempt`).
+2. Adjust `tests/http-client.spec.ts` to cover new retry policy: ensure `GET` and read query requests retry with exponential backoff, and non-idempotent methods do not retry.
+3. Add a changelog entry documenting the retry policy change.
+
+## Acceptance Criteria
+- [x] GET and read query requests retry with exponential backoff.
+- [x] Create, update, save, and delete requests do not retry.
+- [x] Tests cover both retry and non-retry behavior.


### PR DESCRIPTION
## Summary
- restrict retries to GET and read query requests
- apply exponential backoff for retries
- cover retry policy with unit tests and changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0d4d48348321b46bff57ea9a4d44