### PR TITLE
feat: add exponential retry for streams

### DIFF
--- a/changelog/2025-09-04-0308pm-exponential-stream-retry.md
+++ b/changelog/2025-09-04-0308pm-exponential-stream-retry.md
@@ -1,0 +1,13 @@
+# Change: add exponential backoff to stream reconnections
+
+- Date: 2025-09-04 03:08 PM PT
+- Author/Agent: openai-assistant
+- Scope: lib
+- Type: feat
+- Summary:
+  - implement exponential backoff for stream reconnect attempts
+  - add unit test coverage for retry behaviour
+- Impact:
+  - improves reliability of streaming without API changes
+- Follow-ups:
+  - none

--- a/changelog/2025-09-04-0332pm-limit-stream-retries.md
+++ b/changelog/2025-09-04-0332pm-limit-stream-retries.md
@@ -1,0 +1,12 @@
+# Change: cap stream retries at four
+
+- Date: 2025-09-04 03:32 PM PT
+- Author/Agent: openai-agent
+- Scope: lib
+- Type: fix
+- Summary:
+  - limit stream reconnection attempts to four before giving up
+- Impact:
+  - prevents infinite reconnect loops when streams continuously fail
+- Follow-ups:
+  - none

--- a/codex/tasks/library-readiness/finished/022-exponential-stream-retry.md
+++ b/codex/tasks/library-readiness/finished/022-exponential-stream-retry.md
@@ -1,0 +1,15 @@
+# Task: Add exponential retry for stream reconnections
+
+Implement exponential backoff retry logic for streaming connections that drop.
+
+## Plan
+1. Update `src/core/stream.ts` to track retry attempts and delay reconnects using exponential backoff starting at 1s and capping at 30s.
+2. Reset retry counter on successful connection so future reconnects start fresh.
+3. Add tests verifying exponential retry behaviour.
+4. Cap total retry attempts at four to avoid infinite reconnect loops.
+5. Document the change in the changelog.
+
+## Acceptance Criteria
+- [x] Stream reconnections use exponential backoff up to a cap.
+- [x] Unit tests cover retry behaviour.
+- [x] Retry attempts are limited to four.


### PR DESCRIPTION
## Summary
- add exponential backoff for stream reconnections, capped at four retries
- add tests for exponential retry and retry limit

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0d059d58832199e528ae13107efc