### PR TITLE
docs: add examples for missing database methods

### DIFF
--- a/changelog/2025-09-04-1017pm-add-missing-examples.md
+++ b/changelog/2025-09-04-1017pm-add-missing-examples.md
@@ -1,0 +1,12 @@
+# Change: add missing examples for database methods
+
+- Date: 2025-09-04 10:17 PM UTC
+- Author/Agent: OpenAI Assistant
+- Scope: examples
+- Type: docs
+- Summary:
+  - Added examples for save builder, batchSave, cascadeBuilder, and close methods.
+- Impact:
+  - Improves documentation coverage; no public API changes.
+- Follow-ups:
+  - none

--- a/examples/save/batch-save.ts
+++ b/examples/save/batch-save.ts
@@ -1,0 +1,26 @@
+// filename: examples/save/batch-save.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+import { Schema, tables } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const users = Array.from({ length: 5 }, (_, i) => ({
+    id: `batch-user-${i}`,
+    username: `Batch User ${i}`,
+    email: `batch${i}@example.com`,
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }));
+
+  await db.batchSave(tables.User, users, 2);
+
+  console.log('Batch saved users:', users.length);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/save/cascade-builder.ts
+++ b/examples/save/cascade-builder.ts
@@ -1,0 +1,39 @@
+// filename: examples/save/cascade-builder.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+import { Schema, tables } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const rel = db
+    .cascadeBuilder()
+    .graph('profile')
+    .graphType('UserProfile')
+    .targetField('userId')
+    .sourceField('id');
+
+  await db
+    .cascade(rel)
+    .save(tables.User, {
+      id: 'cb-user-1',
+      username: 'Cascade Builder',
+      email: 'cascade-builder@example.com',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      profile: {
+        id: 'cb-profile-1',
+        userId: 'cb-user-1',
+        firstName: 'Cascade',
+        lastName: 'Builder',
+      },
+    });
+
+  console.log('Saved user with cascadeBuilder');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/save/save-builder.ts
+++ b/examples/save/save-builder.ts
@@ -1,0 +1,26 @@
+// filename: examples/save/save-builder.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+import { Schema, tables } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const user = await db
+    .save(tables.User)
+    .one({
+      id: 'builder-user-1',
+      username: 'Builder User',
+      email: 'builder@example.com',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+  console.log('Saved user with builder:', user);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/stream/close.ts
+++ b/examples/stream/close.ts
@@ -1,0 +1,21 @@
+// filename: examples/stream/close.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+import { Schema, tables } from '../onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const handle = await db
+    .from(tables.User)
+    .onItem(() => {})
+    .stream();
+
+  handle.cancel();
+  db.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add builder-style save example
- document batchSave usage
- illustrate cascadeBuilder
- show closing active streams

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba0f292670832188cd1ca3eaac0bb7