### PR TITLE
test: skip smoke test without config

### DIFF
--- a/changelog/2025-09-04-0420pm-skip-smoke-test-without-config.md
+++ b/changelog/2025-09-04-0420pm-skip-smoke-test-without-config.md
@@ -1,0 +1,12 @@
+# Change: skip smoke test without config
+
+- Date: 2025-09-04 04:20 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - run smoke test only when required Onyx credentials are present
+- Impact:
+  - no impact on public API; improves test reliability
+- Follow-ups:
+  - none

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { onyx, eq, contains, startsWith, gt } from '../src';
-import { resolveConfig } from '../src/config/chain';
 
-let hasConfig = true;
-try {
-  await resolveConfig();
-} catch {
-  hasConfig = false;
-}
+const required = [
+  'ONYX_DATABASE_ID',
+  'ONYX_DATABASE_API_KEY',
+  'ONYX_DATABASE_API_SECRET',
+];
+const hasConfig = required.every(k =>
+  typeof process.env[k] === 'string' && process.env[k]!.trim() !== ''
+);
 
 describe.runIf(hasConfig)('smoke e2e', () => {
   it('creates, queries, and deletes a user', async () => {


### PR DESCRIPTION
## Summary
- ensure smoke test only runs when Onyx credentials are present
- document change in changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run test:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ba1e4b38e083218057337c83ce5f3d