### PR TITLE
feat: add missing query examples

### DIFF
--- a/changelog/2025-09-04-0425pm-missing-query-examples.md
+++ b/changelog/2025-09-04-0425pm-missing-query-examples.md
@@ -1,0 +1,12 @@
+# Change: add missing query examples
+
+- Date: 2025-09-04 04:25 PM PT
+- Author/Agent: OpenAI Assistant
+- Scope: examples
+- Type: feat
+- Summary:
+  - add compound query, sorting with paging, list, and update TypeScript examples
+- Impact:
+  - improves example coverage only
+- Follow-ups:
+  - none

--- a/examples/query/compound.ts
+++ b/examples/query/compound.ts
@@ -1,0 +1,21 @@
+// filename: examples/query/compound.ts
+import process from 'node:process';
+import { onyx, eq, startsWith } from '@onyx.dev/onyx-database';
+import { Schema, tables } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const users = await db
+    .from(tables.User)
+    .where(eq('isActive', true))
+    .and(startsWith('username', 'A'))
+    .list();
+
+  console.log(JSON.stringify(users, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/query/list.ts
+++ b/examples/query/list.ts
@@ -1,0 +1,17 @@
+// filename: examples/query/list.ts
+import process from 'node:process';
+import { onyx } from '@onyx.dev/onyx-database';
+import { Schema, tables } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const users = await db.from(tables.User).limit(5).list();
+
+  users.forEach(u => console.log(u.username));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/query/sorting-and-paging.ts
+++ b/examples/query/sorting-and-paging.ts
@@ -1,0 +1,29 @@
+// filename: examples/query/sorting-and-paging.ts
+import process from 'node:process';
+import { onyx, desc } from '@onyx.dev/onyx-database';
+import { Schema, tables } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const firstPage = await db
+    .from(tables.User)
+    .orderBy(desc('username'))
+    .page({ pageSize: 2 });
+
+  console.log('Page 1:', firstPage.records.map(u => u.username));
+
+  if (firstPage.nextPage) {
+    const secondPage = await db
+      .from(tables.User)
+      .orderBy(desc('username'))
+      .nextPage(firstPage.nextPage)
+      .page({ pageSize: 2 });
+    console.log('Page 2:', secondPage.records.map(u => u.username));
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/query/update.ts
+++ b/examples/query/update.ts
@@ -1,0 +1,21 @@
+// filename: examples/query/update.ts
+import process from 'node:process';
+import { onyx, eq } from '@onyx.dev/onyx-database';
+import { Schema, tables } from 'onyx/types';
+
+async function main(): Promise<void> {
+  const db = onyx.init<Schema>();
+
+  const updated = await db
+    .from(tables.User)
+    .where(eq('id', 'example-user-1'))
+    .setUpdates({ isActive: false })
+    .update() as number;
+
+  console.log(`Updated ${updated} record(s).`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add compound criteria query example
- add sorting with paging example
- add list and update query examples

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run gen:onyx` (failed: Missing required config: databaseId, apiKey, apiSecret)
- `npx tsx query/compound.ts` (failed: Missing required config: databaseId, apiKey, apiSecret)
- `npx tsx query/list.ts` (failed: Missing required config: databaseId, apiKey, apiSecret)
- `npx tsx query/sorting-and-paging.ts` (failed: Missing required config: databaseId, apiKey, apiSecret)
- `npx tsx query/update.ts` (failed: Missing required config: databaseId, apiKey, apiSecret)


------
https://chatgpt.com/codex/tasks/task_e_68ba1f0ecdb88321b871f3f821913b53