### PR TITLE
docs: expand compound query example

### DIFF
--- a/changelog/2025-09-05-1049am-complex-compound-query-example.md
+++ b/changelog/2025-09-05-1049am-complex-compound-query-example.md
@@ -1,0 +1,13 @@
+# Change: expand compound query example with nested conditions
+
+- Date: 2025-09-05 10:49 AM PT
+- Author/Agent: OpenAI Assistant
+- Scope: examples
+- Type: docs
+- Summary:
+  - Demonstrated nested AND/OR usage in the compound query example.
+  - Removed an unused variable in the in-partition example to keep lint clean.
+- Impact:
+  - No public API changes; documentation only.
+- Follow-ups:
+  - None

--- a/examples/query/compound.ts
+++ b/examples/query/compound.ts
@@ -8,8 +8,15 @@ async function main(): Promise<void> {
 
   const users = await db
     .from(tables.User)
-    .where(eq('isActive', true))
-    .and(startsWith('username', 'user_'))
+    .where(
+      eq('isActive', true)
+        .and(
+          startsWith('username', 'user_').or(startsWith('email', 'user_'))
+        )
+        .or(
+          eq('role', 'admin').and(startsWith('email', 'admin'))
+        ),
+    )
     .list();
 
   console.log(JSON.stringify(users, null, 2));

--- a/examples/query/in-partition.ts
+++ b/examples/query/in-partition.ts
@@ -4,10 +4,9 @@ import { onyx } from '@onyx.dev/onyx-database';
 import { tables, Schema } from 'onyx/types';
 
 async function main(): Promise<void> {
-  const db = onyx.init<Schema>({requestLoggingEnabled: true});
+  const db = onyx.init<Schema>({ requestLoggingEnabled: true });
 
-  const userA = await db
-    .save(tables.User, {})
+  await db.save(tables.User, {});
 
   const tenantUsers = await db
     .from(tables.User)


### PR DESCRIPTION
## Summary
- show nested AND/OR usage in compound query example
- remove unused variable in partition example to satisfy lint
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run gen:onyx`
- `npm start` *(fails: Missing script "start")*

------
https://chatgpt.com/codex/tasks/task_e_68bb21f570248321bc8fa9372e318c95