### PR TITLE
feat: add audit log seeding and compound query example

### DIFF
--- a/changelog/2025-09-05-0928pm-audit-log-example.md
+++ b/changelog/2025-09-05-0928pm-audit-log-example.md
@@ -1,0 +1,13 @@
+# Change: add audit log seeding and query example
+
+- Date: 2025-09-05 09:28 PM UTC
+- Author/Agent: assistant
+- Scope: examples
+- Type: feat
+- Summary:
+  - add seedAuditLogs function to populate sample audit log entries
+  - update compound query example to filter audit logs
+- Impact:
+  - none; example code only
+- Follow-ups:
+  - none

--- a/examples/query/compound.ts
+++ b/examples/query/compound.ts
@@ -6,20 +6,19 @@ import { Schema, tables } from 'onyx/types';
 async function main(): Promise<void> {
   const db = onyx.init<Schema>();
 
-  const users = await db
-    .from(tables.User)
+  const logs = await db
+    .from(tables.AuditLog)
     .where(
-      eq('isActive', true)
-        .and(
-          startsWith('username', 'user_').or(startsWith('email', 'user_'))
-        )
+      eq('status', 'FAILURE')
+        .and(eq('action', 'DELETE').or(eq('action', 'UPDATE')))
         .or(
-          eq('role', 'admin').and(startsWith('email', 'admin'))
+          eq('actorId', 'admin-user-1').and(startsWith('resource', 'User'))
         ),
     )
+    .orderBy('dateTime', 'desc')
     .list();
 
-  console.log(JSON.stringify(users, null, 2));
+  console.log(JSON.stringify(logs, null, 2));
 }
 
 main().catch((err) => {

--- a/examples/seed.ts
+++ b/examples/seed.ts
@@ -1,6 +1,6 @@
 // filename: examples/seed.ts
 import { onyx } from '@onyx.dev/onyx-database';
-import { tables, Schema, Role, Permission, RolePermission, User } from './onyx/types';
+import { tables, Schema, Role, Permission, RolePermission, User, AuditLog } from './onyx/types';
 
 export async function seed(): Promise<User> {
   const db = onyx.init<Schema>();
@@ -69,4 +69,27 @@ export async function seed(): Promise<User> {
 
   // Return the created user
   return user;
+}
+
+export async function seedAuditLogs(): Promise<AuditLog[]> {
+  const db = onyx.init<Schema>();
+
+  const actions = ['LOGIN', 'CREATE', 'UPDATE', 'DELETE'];
+
+  const logs: AuditLog[] = Array.from({ length: 10 }, (_, i) => ({
+    dateTime: new Date(Date.now() - i * 60000),
+    action: actions[i % actions.length],
+    status: i % 3 === 0 ? 'FAILURE' : 'SUCCESS',
+    actorId: i % 2 === 0 ? 'admin-user-1' : 'service',
+    tenantId: 'tenant-1',
+    targetId: `entity-${i}`,
+    resource: i % 2 === 0 ? 'User' : 'Role',
+    requestId: `req-${i}`,
+    errorCode: i % 3 === 0 ? 'ERR_SAMPLE' : null,
+    errorMessage: i % 3 === 0 ? 'Sample error' : null,
+    changes: null,
+    metadata: null,
+  }));
+
+  return (await db.save(tables.AuditLog, logs)) as AuditLog[];
 }


### PR DESCRIPTION
## Summary
- add `seedAuditLogs` helper to populate sample audit log entries in examples
- switch compound query example to filter `AuditLog` records

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `cd examples && npm run gen:onyx`
- `cd examples && npm start` *(fails: Missing script "start")*
- `cd examples && npx tsx query/compound.ts` *(fails: Missing required config: databaseId, apiKey, apiSecret)*

------
https://chatgpt.com/codex/tasks/task_e_68bb55a2c73883218e460d0d99af5e39