### PR TITLE
fix: skip config file read when credentials provided

### DIFF
--- a/changelog/2025-09-06-skip-home-profile.md
+++ b/changelog/2025-09-06-skip-home-profile.md
@@ -1,0 +1,13 @@
+# Change: skip home profile when explicit config provided
+
+- Date: 2025-09-06 02:05 AM UTC
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Avoid reading project or home profile when explicit config/env already supply required credentials.
+  - Remove unused example import to satisfy lint.
+- Impact:
+  - Prevents unexpected OnyxConfigError from malformed home profiles during init.
+- Follow-ups:
+  - None

--- a/examples/delete/by-id.ts
+++ b/examples/delete/by-id.ts
@@ -1,6 +1,6 @@
 // filename: examples/delete/basic.ts
 import process from 'node:process';
-import { onyx, eq } from '@onyx.dev/onyx-database';
+import { onyx } from '@onyx.dev/onyx-database';
 import { tables, Schema } from 'onyx/types';
 
 async function main(): Promise<void> {

--- a/src/config/chain.ts
+++ b/src/config/chain.ts
@@ -163,8 +163,13 @@ async function readHomeProfile(databaseId?: string): Promise<Partial<OnyxConfig>
 export async function resolveConfig(input?: OnyxConfig): Promise<ResolvedConfig> {
   const env = readEnv(input?.databaseId);
   const targetId = input?.databaseId ?? env.databaseId;
+
+  const haveDbId = !!(input?.databaseId ?? env.databaseId);
+  const haveApiKey = !!(input?.apiKey ?? env.apiKey);
+  const haveApiSecret = !!(input?.apiSecret ?? env.apiSecret);
+
   let file: Partial<OnyxConfig> = {};
-  if (!env.apiKey || !env.apiSecret || !env.databaseId) {
+  if (!(haveDbId && haveApiKey && haveApiSecret)) {
     const project = await readProjectFile(targetId);
     if (Object.keys(project).length) {
       file = project;


### PR DESCRIPTION
## Summary
- avoid reading project or home config files when explicit config or env already has credentials
- clean up unused import in delete example

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb967c612483218e45e1de6fd15b17