### PR TITLE
docs: clarify role and permission modeling

### DIFF
--- a/changelog/2025-09-05-0910pm-role-permission-docs.md
+++ b/changelog/2025-09-05-0910pm-role-permission-docs.md
@@ -1,0 +1,14 @@
+# Change: clarify role and permission modeling
+
+- Date: 2025-09-05 09:10 PM PT
+- Author/Agent: ChatGPT
+- Scope: examples | docs
+- Type: docs
+- Summary:
+  - explain userRoles and rolePermissions join tables
+  - add roles and permissions resolvers for display
+  - align README, docs, and schema examples
+- Impact:
+  - documentation consistency
+- Follow-ups:
+  - none

--- a/changelog/2025-09-07-1200pm-cascade-syntax-fix.md
+++ b/changelog/2025-09-07-1200pm-cascade-syntax-fix.md
@@ -1,0 +1,12 @@
+# Change: clarify cascade save syntax
+
+- Date: 2025-09-07 12:00 PM PT
+- Author/Agent: openai
+- Scope: docs
+- Type: fix
+- Summary:
+  - correct cascade save examples to include graph type and key mapping
+- Impact:
+  - documentation only
+- Follow-ups:
+  - none

--- a/changelog/2025-09-07-1215pm-resolver-syntax-fix.md
+++ b/changelog/2025-09-07-1215pm-resolver-syntax-fix.md
@@ -1,0 +1,13 @@
+# Change: fix roles resolver syntax in sample schema
+
+- Date: 2025-09-07 12:15 PM PT
+- Author/Agent: GPT-4o
+- Scope: examples | docs
+- Type: fix
+- Summary:
+  - correct `roles` resolver to query `Role` via `inOp` lookup
+  - document `resolvers` array in README and API docs
+- Impact:
+  - ensures sample modeling matches working resolver syntax
+- Follow-ups:
+  - none

--- a/changelog/2025-09-07-1230pm-role-permissions-resolver-fix.md
+++ b/changelog/2025-09-07-1230pm-role-permissions-resolver-fix.md
@@ -1,0 +1,13 @@
+# Change: fix role permissions resolver syntax
+
+- Date: 2025-09-07 12:30 PM PT
+- Author/Agent: ChatGPT
+- Scope: examples
+- Type: fix
+- Summary:
+  - Correct Role `permissions` resolver to query `Permission` through `RolePermission` join IDs via `inOp`.
+  - Ensure `rolePermissions` and `permissions` resolvers align in order and usage.
+- Impact:
+  - Documentation schema accuracy; no runtime impact.
+- Follow-ups:
+  - none

--- a/docs/README.md
+++ b/docs/README.md
@@ -178,14 +178,72 @@ export interface UserProfile {
 const user = await db
   .from(tables.User)
   .selectFields('id', 'username')
-  .resolve('role.permissions', 'profile')
+  .resolve('roles.permissions', 'profile')
   .firstOrNull();
 
-// user.role?.permissions -> Permission[]
+// user.roles -> Role[]
+// user.roles[0]?.permissions -> Permission[]
 // user.profile -> UserProfile | undefined
 ```
 
 > The generator defaults to not emitting the JSON copy of your schema. Use `--emit-json` if you want it.
+
+### Modeling users, roles, and permissions
+
+`User` and `Role` form a many-to-many relationship through a `UserRole` join table. `Role` and `Permission` are connected the same way via `RolePermission`.
+
+- **`userRoles` / `rolePermissions` resolvers** return join-table rows. Use these when cascading saves or deletes to add or remove associations.
+- **`roles` / `permissions` resolvers** traverse those joins and return `Role` or `Permission` records for display.
+
+Define these resolvers in your `onyx.schema.json`:
+
+```json
+"resolvers": [
+  {
+    "name": "roles",
+    "resolver": "db.from(\"Role\")\n  .where(\n    inOp(\"id\", \n        db.from(\"UserRole\")\n            .where(eq(\"userId\", this.id))\n            .list()\n            .values('roleId')\n    )\n)\n .list()"
+  },
+  {
+    "name": "profile",
+    "resolver": "db.from(\"UserProfile\")\n .where(eq(\"userId\", this.id))\n .firstOrNull()"
+  },
+  {
+    "name": "userRoles",
+    "resolver": "db.from(\"UserRole\")\n  .where(eq(\"userId\", this.id))\n  .list()"
+  }
+]
+```
+
+Save a user and attach roles in one operation:
+
+```ts
+await db.cascade('userRoles:UserRole(userId, id)').save('User', {
+  id: 'user_126',
+  email: 'dana@example.com',
+  userRoles: [
+    { roleId: 'role_admin' },
+    { roleId: 'role_editor' },
+  ],
+});
+```
+
+Fetch a user with roles and each role's permissions:
+
+```ts
+const detailed = await db
+  .from('User')
+  .resolve('roles.permissions', 'profile')
+  .firstOrNull();
+
+// detailed.roles -> Role[]
+// detailed.roles[0]?.permissions -> Permission[]
+```
+
+Remove a role and its permission links:
+
+```ts
+await db.cascade('rolePermissions').delete('Role', 'role_temp');
+```
 
 ---
 
@@ -263,10 +321,13 @@ await db.save('User', [
 ]);
 
 // Save with cascade relationships (example)
-await db.cascade('User.Role').save('User', {
+await db.cascade('userRoles:UserRole(userId, id)').save('User', {
   id: 'user_126',
   email: 'dana@example.com',
-  Role: ['role_admin', 'role_editor'],
+  userRoles: [
+    { roleId: 'role_admin' },
+    { roleId: 'role_editor' },
+  ],
 });
 
 // Cascade relationship syntax:
@@ -314,10 +375,10 @@ const db = onyx.init();
 await db.delete('User', 'user_125');
 
 // Delete cascading relationships (example)
-await db.delete('Role', 'role_temp', { relationships: ['permission'] });
-// this will delete all of the related permissions that come back from the permissions resolver
+await db.delete('Role', 'role_temp', { relationships: ['rolePermissions'] });
+// this will delete all of the related permissions that come back from the rolePermissions resolver
 // builder pattern equivalent
-await db.cascade('permission').delete('Role', 'role_temp');
+await db.cascade('rolePermissions').delete('Role', 'role_temp');
 ```
 
 ### 4) Delete using query

--- a/examples/onyx.schema.json
+++ b/examples/onyx.schema.json
@@ -72,11 +72,15 @@
       "resolvers": [
         {
           "name": "roles",
-          "resolver": "db.from(\"UserRole\")\n .where(eq(\"userId\", this.id))\n .list()"
+          "resolver": "db.from(\"Role\")\n  .where(\n    inOp(\"id\", \n        db.from(\"UserRole\")\n            .where(eq(\"userId\", this.id))\n            .list()\n            .values('roleId')\n    )\n)\n .list()"
         },
         {
           "name": "profile",
           "resolver": "db.from(\"UserProfile\")\n .where(eq(\"userId\", this.id))\n .firstOrNull()"
+        },
+        {
+          "name": "userRoles",
+          "resolver": "db.from(\"UserRole\")\n  .where(eq(\"userId\", this.id))\n  .list()"
         }
       ],
       "triggers": [],
@@ -238,6 +242,10 @@
       "resolvers": [
         {
           "name": "permissions",
+          "resolver": "db.from(\"Permission\")\n  .where(\n    inOp(\"id\", \n        db.from(\"RolePermission\")\n            .where(eq(\"roleId\", this.id))\n            .list()\n            .values('permissionId')\n    )\n)\n .list()"
+        },
+        {
+          "name": "rolePermissions",
           "resolver": "db.from(\"RolePermission\")\n .where(eq(\"roleId\", this.id))\n .list()"
         }
       ],


### PR DESCRIPTION
## Summary
- explain `userRoles` and `rolePermissions` join tables for many-to-many modeling
- update README and API docs examples to use `userRoles` and `rolePermissions`
- align example `onyx.schema.json` with resolver naming
- correct cascade save examples to include graph type and key mapping
- fix `roles` resolver syntax and document resolvers array in README and API docs
- correct `permissions` resolver to query `Permission` records via `RolePermission` IDs

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm --prefix examples run gen:onyx`
- `npm --prefix examples start` *(fails: Missing script "start")*

------
https://chatgpt.com/codex/tasks/task_e_68bbb33e22508321be43ef54b729182f