### PR TITLE
docs: replace streaming examples with roles and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,19 +352,18 @@ await db.cascade('userRoles:UserRole(userId, id)').save('User', {
 //   source – field on the top level entity used as the key
 
 // Using the CascadeRelationshipBuilder
-const programsCascade = db
+const permission = { id: 'perm_edit_content', description: 'Edit content' };
+const permissionsCascade = db
   .cascadeBuilder()
-  .graph('programs')
-  .graphType('StreamingProgram')
-  .targetField('channelId')
+  .graph('permissions')
+  .graphType('Permission')
+  .targetField('roleId')
   .sourceField('id');
 
-await db.cascade(programsCascade).save('StreamingChannel', {
-  id: 'news_003',
-  category: 'news',
-  name: 'News 24',
-  updatedAt: new Date(),
-  programs: [program], // program defined earlier
+await db.cascade(permissionsCascade).save('Role', {
+  id: 'role_editor',
+  name: 'Editor',
+  permissions: [permission],
 });
 ```
 

--- a/changelog/2025-09-05-1029pm-readme-role-permission-examples.md
+++ b/changelog/2025-09-05-1029pm-readme-role-permission-examples.md
@@ -1,0 +1,12 @@
+# Change: update cascade examples to roles and permissions
+
+- Date: 2025-09-05 10:29 PM PT
+- Author/Agent: OpenAI Assistant
+- Scope: docs
+- Type: docs
+- Summary:
+  - Replace StreamingProgram/StreamingChannel examples with User, Role, and Permission.
+- Impact:
+  - No impact on public API or behavior.
+- Follow-ups:
+  - None

--- a/docs/README.md
+++ b/docs/README.md
@@ -338,30 +338,27 @@ await db.cascade('userRoles:UserRole(userId, id)').save('User', {
 //   source – field on the top level entity used as the key
 
 // Using the CascadeRelationshipBuilder
-const programsCascade = db
+const permission = { id: 'perm_edit_content', description: 'Edit content' };
+const permissionsCascade = db
   .cascadeBuilder()
-  .graph('programs')
-  .graphType('StreamingProgram')
-  .targetField('channelId')
+  .graph('permissions')
+  .graphType('Permission')
+  .targetField('roleId')
   .sourceField('id');
 
-//programsCascade = 'programs:StreamingProgram(channelId, it)'
+//permissionsCascade = 'permissions:Permission(roleId, id)'
 
-await db.cascade(programsCascade).save('StreamingChannel', {
-  id: 'news_003',
-  category: 'news',
-  name: 'News 24',
-  updatedAt: new Date(),
-  programs: [program], // program defined earlier
+await db.cascade(permissionsCascade).save('Role', {
+  id: 'role_editor',
+  name: 'Editor',
+  permissions: [permission],
 });
 
 //you dont have to use the cascadeBuilder
-await db.cascade('programs:StreamingProgram(channelId, it)').save('StreamingChannel', {
-  id: 'news_003',
-  category: 'news',
-  name: 'News 24',
-  updatedAt: new Date(),
-  programs: [program], // program defined earlier
+await db.cascade('permissions:Permission(roleId, id)').save('Role', {
+  id: 'role_editor',
+  name: 'Editor',
+  permissions: [permission],
 });
 ```
 


### PR DESCRIPTION
## Summary
- replace StreamingProgram/StreamingChannel cascade example with Role/Permission in README and docs
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc643bcdc8321b83eb914fba09ba8