### PR TITLE
fix: sanitize newlines in config profiles

### DIFF
--- a/changelog/2025-09-06-0553am-config-newline-fix.md
+++ b/changelog/2025-09-06-0553am-config-newline-fix.md
@@ -1,0 +1,13 @@
+# Change: tolerate stray newlines in config profiles
+
+- Date: 2025-09-06 05:53 AM UTC
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - sanitize JSON config files before parsing to strip newline characters
+  - add regression test for newline handling in profile values
+- Impact:
+  - prevents config parsing failures when values contain leading newlines
+- Follow-ups:
+  - none

--- a/src/config/chain.ts
+++ b/src/config/chain.ts
@@ -70,7 +70,8 @@ async function readProjectFile(databaseId?: string): Promise<Partial<OnyxConfig>
 
   const tryRead = async (p: string): Promise<Partial<OnyxConfig>> => {
     const txt = await fs.readFile(p, 'utf8');
-    const json = dropUndefined<OnyxConfig>(JSON.parse(txt) as Partial<OnyxConfig>);
+    const sanitized = txt.replace(/[\r\n]+/g, '');
+    const json = dropUndefined<OnyxConfig>(JSON.parse(sanitized) as Partial<OnyxConfig>);
     dbg('project file:', p, '→', mask(json));
     return json;
   };
@@ -113,7 +114,8 @@ async function readHomeProfile(databaseId?: string): Promise<Partial<OnyxConfig>
   const readProfile = async (p: string): Promise<Partial<OnyxConfig>> => {
     try {
       const txt = await fs.readFile(p, 'utf8');
-      const json = dropUndefined<OnyxConfig>(JSON.parse(txt) as Partial<OnyxConfig>);
+      const sanitized = txt.replace(/[\r\n]+/g, '');
+      const json = dropUndefined<OnyxConfig>(JSON.parse(sanitized) as Partial<OnyxConfig>);
       dbg('home profile used:', p, '→', mask(json));
       return json;
     } catch (e: unknown) {

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -79,6 +79,29 @@ describe('config chain database selection', () => {
     }
   });
 
+  it('parses profile values with stray newlines', async () => {
+    const homeDir = path.join(homedir(), '.onyx');
+    await mkdir(homeDir, { recursive: true });
+    const file = path.join(homeDir, 'onyx-database.json');
+    const data = `{
+  "baseUrl": "http://home",
+  "databaseId": "hid",
+  "apiKey": "
+key",
+  "apiSecret": "
+secret"
+}`;
+    await writeFile(file, data);
+    try {
+      const cfg = await resolveConfig();
+      expect(cfg.databaseId).toBe('hid');
+      expect(cfg.apiKey).toBe('key');
+      expect(cfg.apiSecret).toBe('secret');
+    } finally {
+      await unlink(file);
+    }
+  });
+
   it('throws when required config is missing', async () => {
     delete process.env.ONYX_DATABASE_ID;
     delete process.env.ONYX_DATABASE_API_KEY;


### PR DESCRIPTION
## Summary
- strip CR/LF characters before parsing config JSON files
- test parsing of profiles containing stray newlines
- document the change in changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbcc15479883218d8ca13850bffc08