### PR TITLE
feat: log request headers when debugging

### DIFF
--- a/changelog/2025-09-07-0311am-request-header-logging.md
+++ b/changelog/2025-09-07-0311am-request-header-logging.md
@@ -1,0 +1,12 @@
+# Change: log request headers when debugging
+
+- Date: 2025-09-07 03:11 AM UTC
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: feat
+- Summary:
+  - Log sanitized request headers when request logging is enabled
+- Impact:
+  - Improves troubleshooting by showing headers without exposing secrets
+- Follow-ups:
+  - none

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -84,18 +84,20 @@ export class HttpClient {
       throw new OnyxConfigError('path must start with /');
     }
     const url = `${this.baseUrl}${path}`;
+    const headers = this.headers({
+      ...(method === 'DELETE' ? { Prefer: 'return=representation' } : {}),
+      ...(extraHeaders ?? {}),
+    });
+    if (body == null) delete headers['Content-Type'];
     if (this.requestLoggingEnabled) {
       console.log(`${method} ${url}`);
       if (body != null) {
         const logBody = typeof body === 'string' ? body : JSON.stringify(body);
         console.log(logBody);
       }
+      const headerLog = { ...headers, 'x-onyx-secret': '[REDACTED]' };
+      console.log('Headers:', headerLog);
     }
-    const headers = this.headers({
-      ...(method === 'DELETE' ? { Prefer: 'return=representation' } : {}),
-      ...(extraHeaders ?? {}),
-    });
-    if (body == null) delete headers['Content-Type'];
     const payload =
       body == null ? undefined : typeof body === 'string' ? body : JSON.stringify(body);
     const init = {

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -105,10 +105,18 @@ describe('HttpClient', () => {
     });
     await client.request('POST', '/log', { a: 1 });
     await client.request('POST', '/log2', '{"b":2}');
+    const hdr = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'x-onyx-key': creds.apiKey,
+      'x-onyx-secret': '[REDACTED]',
+    };
     expect(logSpy).toHaveBeenNthCalledWith(1, `POST ${base}/log`);
     expect(logSpy).toHaveBeenNthCalledWith(2, JSON.stringify({ a: 1 }));
-    expect(logSpy).toHaveBeenNthCalledWith(3, `POST ${base}/log2`);
-    expect(logSpy).toHaveBeenNthCalledWith(4, '{"b":2}');
+    expect(logSpy).toHaveBeenNthCalledWith(3, 'Headers:', hdr);
+    expect(logSpy).toHaveBeenNthCalledWith(4, `POST ${base}/log2`);
+    expect(logSpy).toHaveBeenNthCalledWith(5, '{"b":2}');
+    expect(logSpy).toHaveBeenNthCalledWith(6, 'Headers:', hdr);
     logSpy.mockRestore();
   });
 
@@ -126,8 +134,14 @@ describe('HttpClient', () => {
       requestLoggingEnabled: true,
     });
     await client.request('GET', '/no-body');
-    expect(logSpy).toHaveBeenCalledWith(`GET ${base}/no-body`);
-    expect(logSpy).toHaveBeenCalledTimes(1);
+    const hdr = {
+      Accept: 'application/json',
+      'x-onyx-key': creds.apiKey,
+      'x-onyx-secret': '[REDACTED]',
+    };
+    expect(logSpy).toHaveBeenNthCalledWith(1, `GET ${base}/no-body`);
+    expect(logSpy).toHaveBeenNthCalledWith(2, 'Headers:', hdr);
+    expect(logSpy).toHaveBeenCalledTimes(2);
     logSpy.mockRestore();
   });
 
@@ -185,10 +199,17 @@ describe('HttpClient', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const client = new HttpClient({ baseUrl: base, ...creds, fetchImpl: fetchMock });
     await client.request('POST', '/dbg', { a: 1 });
+    const hdr = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'x-onyx-key': creds.apiKey,
+      'x-onyx-secret': '[REDACTED]',
+    };
     expect(logSpy).toHaveBeenNthCalledWith(1, `POST ${base}/dbg`);
     expect(logSpy).toHaveBeenNthCalledWith(2, JSON.stringify({ a: 1 }));
-    expect(logSpy).toHaveBeenNthCalledWith(3, '200 OK');
-    expect(logSpy).toHaveBeenNthCalledWith(4, JSON.stringify({ ok: true }));
+    expect(logSpy).toHaveBeenNthCalledWith(3, 'Headers:', hdr);
+    expect(logSpy).toHaveBeenNthCalledWith(4, '200 OK');
+    expect(logSpy).toHaveBeenNthCalledWith(5, JSON.stringify({ ok: true }));
     logSpy.mockRestore();
     delete process.env.ONYX_DEBUG;
   });


### PR DESCRIPTION
## Summary
- log request headers when debug logging is enabled
- adjust HttpClient tests for header logging
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run test:smoke` *(fails: Missing required config: databaseId, apiKey, apiSecret)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf48b2f5883219c548b5633222f87