### PR TITLE
feat: log credential source with ONYX_DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ deletes by primary key. Save operations use the partition field on the entity
 itself. Enable `requestLoggingEnabled` to log each request and its body to the
 console. Enable `responseLoggingEnabled` to log responses and bodies. Setting
 the `ONYX_DEBUG=true` environment variable enables both request and response
-logging even if these flags are not set.
+logging even if these flags are not set. It also logs the source of resolved
+credentials (env, project file, home profile, or explicit config).
 
 ### Option C) Node-only config files
 

--- a/changelog/2025-09-07-0850am-credential-source-logging.md
+++ b/changelog/2025-09-07-0850am-credential-source-logging.md
@@ -1,0 +1,12 @@
+# Change: log credential source when ONYX_DEBUG=true
+
+- Date: 2025-09-07 08:50 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: feat
+- Summary:
+  - Log origin of resolved credentials when ONYX_DEBUG is enabled.
+- Impact:
+  - Debug runs now report credential sources; no API changes.
+- Follow-ups:
+  - none

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -108,5 +108,19 @@ secret"
     delete process.env.ONYX_DATABASE_API_SECRET;
     await expect(resolveConfig()).rejects.toBeInstanceOf(OnyxConfigError);
   });
+
+  it('logs credential source when ONYX_DEBUG=true', async () => {
+    process.env.ONYX_DEBUG = 'true';
+    process.env.ONYX_DATABASE_ID = 'envdb';
+    process.env.ONYX_DATABASE_API_KEY = 'k';
+    process.env.ONYX_DATABASE_API_SECRET = 's';
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    await resolveConfig();
+    const call = spy.mock.calls.find(([msg]) =>
+      msg.includes('credential source: {"databaseId":"env","apiKey":"env","apiSecret":"env"}'),
+    );
+    expect(call).toBeTruthy();
+    spy.mockRestore();
+  });
 });
 


### PR DESCRIPTION
## Summary
- log which config source supplies credentials when `ONYX_DEBUG=true`
- document credential source logging and add regression test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda94794f48321bd0e1edcdb1ab599