### PR TITLE
fix: guard resolveConfig against stray env vars

### DIFF
--- a/changelog/2025-09-07-0848am-config-chain-env.md
+++ b/changelog/2025-09-07-0848am-config-chain-env.md
@@ -1,0 +1,13 @@
+# Change: tighten env matching in config resolver
+
+- Date: 2025-09-07 08:48 AM PT
+- Author/Agent: ChatGPT
+- Scope: lib | test
+- Type: fix
+- Summary:
+  - Ignore environment credentials unless ONYX_DATABASE_ID matches the target.
+  - Clean tests of stray ONYX_* variables.
+- Impact:
+  - Prevents unexpected credential leaks from unrelated env vars.
+- Follow-ups:
+  - None

--- a/changelog/2025-09-07-0910am-drop-next-env-vars.md
+++ b/changelog/2025-09-07-0910am-drop-next-env-vars.md
@@ -1,0 +1,12 @@
+# Change: remove NEXT_* env var references from tests
+
+- Date: 2025-09-07 09:10 AM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - Drop references to NEXT_ONYX_* variables in config chain tests.
+- Impact:
+  - Avoids implying unsupported environment variable prefixes.
+- Follow-ups:
+  - None

--- a/src/config/chain.ts
+++ b/src/config/chain.ts
@@ -50,10 +50,10 @@ function readEnv(targetId?: string): Partial<OnyxConfig> {
   };
 
   const envId = pick('ONYX_DATABASE_ID');
-  if (targetId && envId && targetId !== envId) return {};
+  if (targetId && envId !== targetId) return {};
   const res = dropUndefined<OnyxConfig>({
     baseUrl: pick('ONYX_DATABASE_BASE_URL'),
-    databaseId: targetId ?? envId,
+    databaseId: envId,
     apiKey: pick('ONYX_DATABASE_API_KEY'),
     apiSecret: pick('ONYX_DATABASE_API_SECRET'),
   });

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -6,6 +6,12 @@ import path from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 
 const origEnv = { ...process.env };
+for (const k of Object.keys(origEnv)) {
+  if (k.startsWith('ONYX_DATABASE')) {
+    delete origEnv[k as keyof typeof origEnv];
+    delete process.env[k];
+  }
+}
 const origCwd = process.cwd();
 const origHome = process.env.HOME;
 
@@ -25,14 +31,6 @@ describe('config chain database selection', () => {
     expect(cfg.baseUrl).toBe('http://env');
     expect(cfg.apiKey).toBe('k');
     expect(cfg.apiSecret).toBe('s');
-  });
-
-  it('ignores NEXT_* env vars', async () => {
-    process.env.NEXT_ONYX_DATABASE_ID = 'nid';
-    process.env.NEXT_ONYX_DATABASE_BASE_URL = 'http://next';
-    process.env.NEXT_ONYX_DATABASE_API_KEY = 'nk';
-    process.env.NEXT_ONYX_DATABASE_API_SECRET = 'ns';
-    await expect(resolveConfig({ databaseId: 'nid' })).rejects.toBeInstanceOf(OnyxConfigError);
   });
 
   it('prefers project file over home profile when env id differs', async () => {


### PR DESCRIPTION
## Summary
- ensure `resolveConfig` only uses environment credentials when `ONYX_DATABASE_ID` matches the requested database
- drop references to unsupported `NEXT_ONYX_*` environment variables from config-chain tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_68bda80a03248321aef9e57e015388cf