### PR TITLE
test: isolate config-chain tests from host config

### DIFF
--- a/changelog/2025-09-07-0151pm-config-chain-env-cleanup.md
+++ b/changelog/2025-09-07-0151pm-config-chain-env-cleanup.md
@@ -1,0 +1,12 @@
+# Change: isolate config chain tests from host env
+
+- Date: 2025-09-07 01:51 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - clear ONYX_CONFIG_PATH in config-chain tests to prevent interference from host environment variables.
+- Impact:
+  - avoids false positives or failures when ONYX_CONFIG_PATH is set.
+- Follow-ups:
+  - none

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -7,7 +7,7 @@ import { tmpdir, homedir } from 'node:os';
 
 const origEnv = { ...process.env };
 for (const k of Object.keys(origEnv)) {
-  if (k.startsWith('ONYX_DATABASE')) {
+  if (k.startsWith('ONYX_DATABASE') || k === 'ONYX_CONFIG_PATH') {
     delete origEnv[k as keyof typeof origEnv];
     delete process.env[k];
   }


### PR DESCRIPTION
## Summary
- ensure config chain tests remove ONYX_CONFIG_PATH so host environment variables don't interfere
- record change in changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdefe1d52883218ecb4190b8edbd72