### PR TITLE
test: isolate config cache env

### DIFF
--- a/changelog/2025-09-07-0212pm-config-cache-explicit-config.md
+++ b/changelog/2025-09-07-0212pm-config-cache-explicit-config.md
@@ -1,0 +1,13 @@
+# Change: avoid env leakage in config cache tests
+
+- Date: 2025-09-07 02:12 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - Replace environment-based setup in config cache tests with explicit configuration.
+  - Prevents cross-test interference from global environment variables.
+- Impact:
+  - Ensures stable test runs without affecting runtime behavior.
+- Follow-ups:
+  - none

--- a/tests/config-cache.spec.ts
+++ b/tests/config-cache.spec.ts
@@ -2,10 +2,9 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { onyx } from '../src';
 import * as chain from '../src/config/chain';
 
-const origEnv = { ...process.env };
+const cfg = { baseUrl: 'http://env', databaseId: 'id', apiKey: 'k', apiSecret: 's' };
 
 afterEach(() => {
-  process.env = { ...origEnv };
   onyx.clearCacheConfig();
   vi.useRealTimers();
 });
@@ -13,13 +12,9 @@ afterEach(() => {
 describe('config cache', () => {
   it('reuses resolved config within ttl', () => {
     const spy = vi.spyOn(chain, 'resolveConfig');
-    process.env.ONYX_DATABASE_ID = 'id';
-    process.env.ONYX_DATABASE_API_KEY = 'k';
-    process.env.ONYX_DATABASE_API_SECRET = 's';
-    process.env.ONYX_DATABASE_BASE_URL = 'http://env';
 
-    onyx.init();
-    onyx.init();
+    onyx.init(cfg);
+    onyx.init(cfg);
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -27,29 +22,21 @@ describe('config cache', () => {
   it('expires cache after ttl', () => {
     vi.useFakeTimers();
     const spy = vi.spyOn(chain, 'resolveConfig');
-    process.env.ONYX_DATABASE_ID = 'id';
-    process.env.ONYX_DATABASE_API_KEY = 'k';
-    process.env.ONYX_DATABASE_API_SECRET = 's';
-    process.env.ONYX_DATABASE_BASE_URL = 'http://env';
 
-    onyx.init({ ttl: 100 });
-    onyx.init({ ttl: 100 });
+    onyx.init({ ...cfg, ttl: 100 });
+    onyx.init({ ...cfg, ttl: 100 });
     expect(spy).toHaveBeenCalledTimes(1);
     vi.advanceTimersByTime(101);
-    onyx.init({ ttl: 100 });
+    onyx.init({ ...cfg, ttl: 100 });
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('clearCacheConfig forces re-resolve', () => {
     const spy = vi.spyOn(chain, 'resolveConfig');
-    process.env.ONYX_DATABASE_ID = 'id';
-    process.env.ONYX_DATABASE_API_KEY = 'k';
-    process.env.ONYX_DATABASE_API_SECRET = 's';
-    process.env.ONYX_DATABASE_BASE_URL = 'http://env';
 
-    onyx.init();
+    onyx.init(cfg);
     onyx.clearCacheConfig();
-    onyx.init();
+    onyx.init(cfg);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- avoid using process.env in config cache tests to prevent cross-test leakage
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf41c9ea883218aba230ebea82270