### PR TITLE
Isolate home directory in config-chain tests

### DIFF
--- a/changelog/2025-09-07-0223pm-config-chain-test-home-isolation.md
+++ b/changelog/2025-09-07-0223pm-config-chain-test-home-isolation.md
@@ -1,0 +1,13 @@
+# Change: isolate home dir in config chain tests
+
+- Date: 2025-09-07 02:23 PM PT
+- Author/Agent: OpenAI ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - mock Node's home directory to avoid reading user profiles in config-chain tests
+  - ensure tests run reliably regardless of developer environment
+- Impact:
+  - improves test isolation; no change to runtime code
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- mock `node:os` in config-chain tests so they no longer read the real home profile
- document change in changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf5c0f1a883219d9e1f172235f234