### PR TITLE
test: stub env vars in config-chain spec

### DIFF
--- a/changelog/2025-09-07-0233pm-stub-env-config-chain-tests.md
+++ b/changelog/2025-09-07-0233pm-stub-env-config-chain-tests.md
@@ -1,0 +1,13 @@
+# Change: stub env vars in config-chain tests
+
+- Date: 2025-09-07 02:33 PM PT
+- Author/Agent: OpenAI ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - replace manual environment mutations with vi.stubEnv for better isolation
+  - avoid cross-test interference by restoring env after each run
+- Impact:
+  - stabilizes config resolution test behavior; no runtime effect
+- Follow-ups:
+  - none


### PR DESCRIPTION
## Summary
- use vi.stubEnv to isolate config-chain environment variables
- reset env and mocks after each test to avoid cross-file interference

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf8d823048321a288e77415b6a3bd