### PR TITLE
test: clear ONYX env vars after config chain tests

### DIFF
--- a/changelog/2025-09-07-0244pm-config-chain-env-reset.md
+++ b/changelog/2025-09-07-0244pm-config-chain-env-reset.md
@@ -1,0 +1,12 @@
+# Change: reset ONYX env vars after config chain tests
+
+- Date: 2025-09-07 02:44 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - clear ONYX_* environment variables after each config-chain test to ensure isolation.
+- Impact:
+  - prevents host credentials from interfering with tests.
+- Follow-ups:
+  - none

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -12,6 +12,9 @@ const origCwd = process.cwd();
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  for (const k of Object.keys(process.env)) {
+    if (k.startsWith('ONYX_DATABASE') || k === 'ONYX_CONFIG_PATH') delete process.env[k];
+  }
   process.chdir(origCwd);
   vi.doUnmock('node:os');
 });


### PR DESCRIPTION
## Summary
- ensure config-chain tests purge ONYX_* env vars after each run to avoid interference from host credentials
- document change in changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc22864883218857b418f40b11e9