### PR TITLE
test: reset Onyx env before config-chain specs

### DIFF
--- a/changelog/2025-09-07-0251pm-config-chain-env-reset.md
+++ b/changelog/2025-09-07-0251pm-config-chain-env-reset.md
@@ -1,0 +1,12 @@
+# Change: isolate config-chain tests from host env
+
+- Date: 2025-09-07 02:51 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - clear ONYX environment variables before each config-chain test to avoid flakiness
+- Impact:
+  - ensures tests pass when host defines ONYX env vars
+- Follow-ups:
+  - none

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -1,20 +1,27 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { resolveConfig } from '../src/config/chain';
 import { OnyxConfigError } from '../src/errors/config-error';
 import { mkdtemp, writeFile, mkdir, unlink } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 
-for (const k of Object.keys(process.env)) {
-  if (k.startsWith('ONYX_DATABASE') || k === 'ONYX_CONFIG_PATH') delete process.env[k];
-}
-const origCwd = process.cwd();
-
-afterEach(() => {
-  vi.unstubAllEnvs();
+const clearEnv = (): void => {
   for (const k of Object.keys(process.env)) {
     if (k.startsWith('ONYX_DATABASE') || k === 'ONYX_CONFIG_PATH') delete process.env[k];
   }
+};
+
+clearEnv();
+const origCwd = process.cwd();
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  clearEnv();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  clearEnv();
   process.chdir(origCwd);
   vi.doUnmock('node:os');
 });


### PR DESCRIPTION
## Summary
- ensure config-chain tests clear any ONYX env vars before each run
- record the change in the changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfd74d49083218aad0150cf0e6608