### PR TITLE
chore: improve config debug logging

### DIFF
--- a/changelog/2025-09-07-1000pm-debug-logging-json.md
+++ b/changelog/2025-09-07-1000pm-debug-logging-json.md
@@ -1,0 +1,13 @@
+# Change: improve debug object logging
+
+- Date: 2025-09-07 10:00 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: chore
+- Summary:
+  - Serialize objects to JSON in debug output when ONYX_DEBUG=true.
+  - Makes config resolution logs easier to read.
+- Impact:
+  - Debug-only improvement; no runtime behavior change.
+- Follow-ups:
+  - None

--- a/src/config/chain.ts
+++ b/src/config/chain.ts
@@ -25,7 +25,15 @@ const isNode = !!gProcess?.versions?.node;
 // Optional debug logger — enable with ONYX_DEBUG=true (Node only)
 const dbg = (...args: unknown[]): void => {
   if (gProcess?.env?.ONYX_DEBUG == "true") {
-    gProcess.stderr?.write?.(`[onyx-config] ${args.map(String).join(' ')}\n`);
+    const fmt = (v: unknown): string => {
+      if (typeof v === 'string') return v;
+      try {
+        return JSON.stringify(v);
+      } catch {
+        return String(v);
+      }
+    };
+    gProcess.stderr?.write?.(`[onyx-config] ${args.map(fmt).join(' ')}\n`);
   }
 };
 


### PR DESCRIPTION
## Summary
- serialize debug logger arguments as JSON for clearer ONYX_DEBUG output

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdff2e67f08321b8f77b00529b4ec8