### PR TITLE
fix: sanitize env newline characters

### DIFF
--- a/changelog/2025-09-07-0308pm-env-newline.md
+++ b/changelog/2025-09-07-0308pm-env-newline.md
@@ -1,0 +1,13 @@
+# Change: sanitize env newline characters
+
+- Date: 2025-09-07 03:08 PM PT
+- Author/Agent: openai
+- Scope: lib
+- Type: fix
+- Summary:
+  - Strip carriage returns and newlines from ONYX_DATABASE_* environment variables during config resolution.
+  - Aligns env handling with profile file parsing.
+- Impact:
+  - Improves robustness when environment values contain stray line breaks.
+- Follow-ups:
+  - none

--- a/src/config/chain.ts
+++ b/src/config/chain.ts
@@ -52,7 +52,10 @@ function readEnv(targetId?: string): Partial<OnyxConfig> {
   const pick = (...keys: string[]): string | undefined => {
     for (const k of keys) {
       const v = env[k];
-      if (typeof v === 'string' && v.trim() !== '') return v.trim();
+      if (typeof v === 'string') {
+        const cleaned = v.replace(/[\r\n]+/g, '').trim();
+        if (cleaned !== '') return cleaned;
+      }
     }
     return undefined;
   };


### PR DESCRIPTION
## Summary
- strip carriage returns and newlines from ONYX_DATABASE_* environment variables when resolving config
- document environment newline sanitization

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be013866808321bd93223362396181