### PR TITLE
test: isolate config-chain env vars

### DIFF
--- a/changelog/2025-09-07-0315pm-config-chain-env-stubs.md
+++ b/changelog/2025-09-07-0315pm-config-chain-env-stubs.md
@@ -1,0 +1,12 @@
+# Change: stabilize config-chain tests
+
+- Date: 2025-09-07 03:15 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: test
+- Summary:
+  - stub ONYX env variables so config-chain specs ignore developer credentials
+- Impact:
+  - prevents cross-env failures during testing
+- Follow-ups:
+  - none

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -71,6 +71,7 @@ describe('config chain database selection', () => {
       JSON.stringify({ baseUrl: 'http://home', databaseId: 'hid', apiKey: 'hk', apiSecret: 'hs' }),
     );
 
+    vi.stubEnv('ONYX_DATABASE_ID', '');
     vi.stubEnv('ONYX_DATABASE_API_KEY', 'ek');
     vi.stubEnv('ONYX_DATABASE_API_SECRET', 'es');
 
@@ -102,6 +103,9 @@ secret"
 }`;
     await writeFile(file, data);
     try {
+      vi.stubEnv('ONYX_DATABASE_ID', '');
+      vi.stubEnv('ONYX_DATABASE_API_KEY', '');
+      vi.stubEnv('ONYX_DATABASE_API_SECRET', '');
       const cfg = await resolveConfig();
       expect(cfg.databaseId).toBe('hid');
       expect(cfg.apiKey).toBe('key');
@@ -144,6 +148,9 @@ secret"
     const home = await mkdtemp(path.join(tmpdir(), 'home-'));
     vi.stubEnv('HOME', home);
     vi.doMock('node:os', () => ({ homedir: () => home }));
+    vi.stubEnv('ONYX_DATABASE_ID', '');
+    vi.stubEnv('ONYX_DATABASE_API_KEY', '');
+    vi.stubEnv('ONYX_DATABASE_API_SECRET', '');
     await expect(resolveConfig()).rejects.toBeInstanceOf(OnyxConfigError);
   });
 


### PR DESCRIPTION
## Summary
- stub ONYX env variables in config-chain tests to avoid host interference
- add changelog entry

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0302a7f88321a4f3c51b855f05ed