### PR TITLE
test: isolate config-chain tests from project files

### DIFF
--- a/changelog/2025-09-07-0323pm-config-chain-project-isolation.md
+++ b/changelog/2025-09-07-0323pm-config-chain-project-isolation.md
@@ -1,0 +1,13 @@
+# Change: isolate config-chain tests from project files
+
+- Date: 2025-09-07 03:23 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: fix
+- Summary:
+  - change config-chain tests to run in temp directories without project config
+  - prevents local project files from affecting test expectations
+- Impact:
+  - more reliable tests; no runtime changes
+- Follow-ups:
+  - none

--- a/tests/config-chain.spec.ts
+++ b/tests/config-chain.spec.ts
@@ -60,6 +60,8 @@ describe('config chain database selection', () => {
   });
 
   it('supplements env with home profile when database id missing', async () => {
+    const proj = await mkdtemp(path.join(tmpdir(), 'proj-'));
+    process.chdir(proj);
     const home = await mkdtemp(path.join(tmpdir(), 'home-'));
     vi.stubEnv('HOME', home);
     vi.doMock('node:os', () => ({ homedir: () => home }));
@@ -87,6 +89,8 @@ describe('config chain database selection', () => {
   });
 
   it('parses profile values with stray newlines', async () => {
+    const proj = await mkdtemp(path.join(tmpdir(), 'proj-'));
+    process.chdir(proj);
     const home = await mkdtemp(path.join(tmpdir(), 'home-'));
     vi.stubEnv('HOME', home);
     vi.doMock('node:os', () => ({ homedir: () => home }));
@@ -145,6 +149,8 @@ secret"
   });
 
   it('throws when required config is missing', async () => {
+    const proj = await mkdtemp(path.join(tmpdir(), 'proj-'));
+    process.chdir(proj);
     const home = await mkdtemp(path.join(tmpdir(), 'home-'));
     vi.stubEnv('HOME', home);
     vi.doMock('node:os', () => ({ homedir: () => home }));


### PR DESCRIPTION
## Summary
- ensure config-chain specs run in temp dirs so local project files don't affect results
- record change in changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be04f269788321bbc8fbfcb2d2e1f3