### PR TITLE
fix: update credential precedence chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The package is dual-module (ESM + CJS) and has **no runtime or peer dependencies
 
 ## Initialize the client
 
-This SDK resolves credentials automatically from **environment variables** (when `process.env` is available), **project or home config files** _(Node.js only)_, or explicit config. Call `onyx.init({ databaseId: 'database-id' })` to target a specific database, or omit the `databaseId` to use the default. You can also pass credentials directly via config.
+This SDK resolves credentials automatically using the chain **explicit config ➜ environment variables ➜ `ONYX_CONFIG_PATH` file ➜ project config file ➜ home profile** _(Node.js only for file-based sources)_. Call `onyx.init({ databaseId: 'database-id' })` to target a specific database, or omit the `databaseId` to use the default. You can also pass credentials directly via config.
 
 ### Option A) Environment variables (recommended for production)
 
@@ -86,11 +86,11 @@ itself. Enable `requestLoggingEnabled` to log each request and its body to the
 console. Enable `responseLoggingEnabled` to log responses and bodies. Setting
 the `ONYX_DEBUG=true` environment variable enables both request and response
 logging even if these flags are not set. It also logs the source of resolved
-credentials (env, config path, project file, home profile, or explicit config).
+credentials (explicit config, env vars, config path file, project file, or home profile).
 
 ### Option C) Node-only config files
 
-Set `ONYX_CONFIG_PATH` to a JSON file containing your credentials to bypass the default search. When unset, the resolver checks for JSON files matching the `OnyxConfig` shape in the following order:
+Set `ONYX_CONFIG_PATH` to a JSON file containing your credentials. This file is checked after environment variables and before project and home files. When unset, the resolver checks for JSON files matching the `OnyxConfig` shape in the following order:
 
 - `./onyx-database-<databaseId>.json`
 - `./onyx-database.json`

--- a/changelog/2025-09-07-1034pm-config-chain-precedence.md
+++ b/changelog/2025-09-07-1034pm-config-chain-precedence.md
@@ -1,0 +1,14 @@
+# Change: update credential chain precedence
+
+- Date: 2025-09-07 10:34 PM UTC
+- Author/Agent: OpenAI ChatGPT
+- Scope: lib | docs | test
+- Type: fix
+- Summary:
+  - prioritize explicit config over env vars, config path, project, and home files
+  - add tests and docs for new credential resolution order
+- Impact:
+  - behavior: env vars now override ONYX_CONFIG_PATH
+- Follow-ups:
+  - none
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ The package is dual-module (ESM + CJS) and has **no runtime or peer dependencies
 
 ## Initialize the client
 
-This SDK resolves credentials automatically using the chain **environment ➜ project file ➜ home profile** (highest to lowest precedence). Set `ONYX_CONFIG_PATH` to a JSON file to skip the default chain. Call `onyx.init({ databaseId: 'database-id' })` to target a specific database, or omit the `databaseId` to use the default. You can also pass credentials directly via config.
+This SDK resolves credentials automatically using the chain **explicit config ➜ environment variables ➜ `ONYX_CONFIG_PATH` file ➜ project file ➜ home profile** (highest to lowest precedence). Call `onyx.init({ databaseId: 'database-id' })` to target a specific database, or omit the `databaseId` to use the default. You can also pass credentials directly via config.
 
 ### Option A) Environment variables (recommended for production)
 
@@ -69,7 +69,7 @@ const db = onyx.init({ databaseId: 'YOUR_DATABASE_ID' }); // uses env when ID ma
 
 ### Option B) Config file via `ONYX_CONFIG_PATH`
 
-Set `ONYX_CONFIG_PATH` to a relative or absolute path to a JSON file containing your `baseUrl`, `databaseId`, `apiKey`, and `apiSecret`. When set, the resolver loads only this file.
+Set `ONYX_CONFIG_PATH` to a relative or absolute path to a JSON file containing your `baseUrl`, `databaseId`, `apiKey`, and `apiSecret`. The resolver loads this file after environment variables. If any values are missing, project and home files are checked as fallbacks.
 
 ### Option C) Project file (checked into *your app* repo)
 


### PR DESCRIPTION
## Summary
- prioritize explicit config over env vars, `ONYX_CONFIG_PATH`, project, and home files in credential resolver
- document new credential resolution order
- test env and `ONYX_CONFIG_PATH` precedence

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be079c99dc8321aa8c463eeb26e5c9