### PR TITLE
test: isolate ONYX_DEBUG in HttpClient tests

### DIFF
--- a/changelog/2025-09-07-0443pm-reset-onyx-debug-http-tests.md
+++ b/changelog/2025-09-07-0443pm-reset-onyx-debug-http-tests.md
@@ -1,0 +1,12 @@
+# Change: reset ONYX_DEBUG in HttpClient tests
+
+- Date: 2025-09-07 04:43 PM PT
+- Author/Agent: ChatGPT
+- Scope: test
+- Type: test
+- Summary:
+  - clear ONYX_DEBUG env var before each HttpClient test to prevent cross-test interference
+- Impact:
+  - ensures tests pass even when ONYX_DEBUG is set globally
+- Follow-ups:
+  - none

--- a/tests/http-client.spec.ts
+++ b/tests/http-client.spec.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { inspect } from 'node:util';
 import { HttpClient, parseJsonAllowNaN } from '../src/core/http';
 import { OnyxHttpError } from '../src/errors/http-error';
 
 // filename: tests/http-client.spec.ts
+
+beforeEach(() => {
+  delete process.env.ONYX_DEBUG;
+});
 
 describe('parseJsonAllowNaN', () => {
   it('parses valid JSON normally', () => {


### PR DESCRIPTION
## Summary
- reset ONYX_DEBUG env var before each HttpClient test to avoid unexpected logging
- add changelog entry for test isolation

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be18511d58832188bebc9e7233a6f2