### PR TITLE
docs: add npm version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @onyx.dev/onyx-database
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE) [![codecov](https://codecov.io/gh/OnyxDevTools/onyx-database/branch/main/graph/badge.svg)](https://codecov.io/gh/OnyxDevTools/onyx-database)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE) [![codecov](https://codecov.io/gh/OnyxDevTools/onyx-database/branch/main/graph/badge.svg)](https://codecov.io/gh/OnyxDevTools/onyx-database) [![npm version](https://img.shields.io/npm/v/%40onyx.dev/onyx-database.svg)](https://www.npmjs.com/package/@onyx.dev/onyx-database)
 
 TypeScript client SDK for **Onyx Cloud Database** — a zero-dependency, strict-typed, builder-pattern API for querying and persisting data in Onyx from Node.js or edge runtimes like Cloudflare Workers. Ships ESM & CJS, includes a credential resolver, and an optional **schema code generator** that produces table-safe types and a `tables` enum.
 

--- a/changelog/2025-09-07-0454pm-npm-version-badge.md
+++ b/changelog/2025-09-07-0454pm-npm-version-badge.md
@@ -1,0 +1,14 @@
+# Change: add npm version badge to README
+
+- Date: 2025-09-07 04:54 PM PT
+- Author/Agent: ChatGPT
+- Scope: docs
+- Type: docs
+- Summary:
+  - Added npm version publish badge alongside existing license and code coverage badges in README.
+
+- Impact:
+  - Documentation only.
+
+- Follow-ups:
+  - None


### PR DESCRIPTION
## Summary
- add npm version publish badge to README alongside existing badges
- document the documentation update in changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be1b101cd883218827a5cc43aae5d6