### PR TITLE
fix: defer node-only imports for workers

### DIFF
--- a/changelog/2025-09-07-0620pm-worker-import-fix.md
+++ b/changelog/2025-09-07-0620pm-worker-import-fix.md
@@ -1,0 +1,12 @@
+# Change: hide Node builtins from bundlers
+
+- Date: 2025-09-07 06:20 PM PT
+- Author/Agent: openhands
+- Scope: lib
+- Type: fix
+- Summary:
+  - wrap Node-only config helpers in dynamic import to prevent bundlers from resolving built-in modules
+- Impact:
+  - enables bundling in Worker environments that only rely on environment variables
+- Follow-ups:
+  - none

--- a/src/config/chain.ts
+++ b/src/config/chain.ts
@@ -46,6 +46,11 @@ function dropUndefined<T extends object>(obj: Partial<T> | undefined): Partial<T
   return out as Partial<T>;
 }
 
+// Lazy import helper to hide Node-only modules from bundlers
+async function nodeImport<T>(spec: string): Promise<T> {
+  return import(/* @vite-ignore */ spec) as Promise<T>;
+}
+
 function readEnv(targetId?: string): Partial<OnyxConfig> {
   if (!gProcess?.env) return {};
   const env = gProcess.env;
@@ -75,8 +80,8 @@ function readEnv(targetId?: string): Partial<OnyxConfig> {
 
 async function readProjectFile(databaseId?: string): Promise<Partial<OnyxConfig>> {
   if (!isNode) return {};
-  const fs = await import('node:fs/promises');
-  const path = await import('node:path');
+  const fs = await nodeImport<typeof import('node:fs/promises')>('node:fs/promises');
+  const path = await nodeImport<typeof import('node:path')>('node:path');
   const cwd = gProcess?.cwd?.() ?? '.';
 
   const tryRead = async (p: string): Promise<Partial<OnyxConfig>> => {
@@ -107,9 +112,9 @@ async function readProjectFile(databaseId?: string): Promise<Partial<OnyxConfig>
 
 async function readHomeProfile(databaseId?: string): Promise<Partial<OnyxConfig>> {
   if (!isNode) return {};
-  const fs = await import('node:fs/promises');
-  const os = await import('node:os');
-  const path = await import('node:path');
+  const fs = await nodeImport<typeof import('node:fs/promises')>('node:fs/promises');
+  const os = await nodeImport<typeof import('node:os')>('node:os');
+  const path = await nodeImport<typeof import('node:path')>('node:path');
 
   const home = os.homedir();
   const dir = path.join(home, '.onyx');
@@ -171,8 +176,8 @@ async function readHomeProfile(databaseId?: string): Promise<Partial<OnyxConfig>
 
 async function readConfigPath(p: string): Promise<Partial<OnyxConfig>> {
   if (!isNode) return {};
-  const fs = await import('node:fs/promises');
-  const path = await import('node:path');
+  const fs = await nodeImport<typeof import('node:fs/promises')>('node:fs/promises');
+  const path = await nodeImport<typeof import('node:path')>('node:path');
   const cwd = gProcess?.cwd?.() ?? '.';
   const resolved = path.isAbsolute(p) ? p : path.resolve(cwd, p);
   try {


### PR DESCRIPTION
## Summary
- defer Node-only config helpers behind dynamic import to avoid bundler resolution
- document bundler workaround

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be2e149ec883218b4dcd73cbe943d3