### PR TITLE
fix: support non-iterable records in QueryResults

### DIFF
--- a/changelog/2025-09-09-1010am-query-results-spread-support.md
+++ b/changelog/2025-09-09-1010am-query-results-spread-support.md
@@ -1,0 +1,13 @@
+# Change: support non-iterable records in QueryResults
+
+- Date: 2025-09-09 10:10 AM PT
+- Author/Agent: openai
+- Scope: lib
+- Type: fix
+- Summary:
+  - allow QueryResults to accept arrays, iterables, or single records
+  - prevent spread syntax errors on non-iterable input
+- Impact:
+  - improves robustness; no API break
+- Follow-ups:
+  - none

--- a/src/builders/query-results.ts
+++ b/src/builders/query-results.ts
@@ -27,8 +27,24 @@ export class QueryResults<T> extends Array<T> {
     * const results = new QueryResults(users, token, t => fetchMore(t));
     * ```
     */
-  constructor(records: T[], nextPage: string | null, fetcher?: (token: string) => Promise<QueryResults<T>>) {
-    super(...records);
+  constructor(
+    records: Iterable<T> | ArrayLike<T> | T | null | undefined,
+    nextPage: string | null,
+    fetcher?: (token: string) => Promise<QueryResults<T>>,
+  ) {
+    const items: T[] = (() => {
+      if (records == null) return [];
+      if (Array.isArray(records)) return records;
+      if (typeof (records as any)[Symbol.iterator] === 'function') {
+        return Array.from(records as Iterable<T>);
+      }
+      if (typeof (records as any).length === 'number') {
+        return Array.from(records as ArrayLike<T>);
+      }
+      return [records as T];
+    })();
+
+    super(...items);
     Object.setPrototypeOf(this, new.target.prototype);
     this.nextPage = nextPage;
     this.fetcher = fetcher;

--- a/tests/query-results.spec.ts
+++ b/tests/query-results.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { QueryBuilder } from '../src/builders/query-builder';
+import { QueryResults } from '../src/builders/query-results';
 
 function makeExec() {
   return {
@@ -102,5 +103,21 @@ describe('QueryResults', () => {
     const empty = new (res.constructor as any)([], null);
     expect(empty.firstOrNull()).toBeNull();
     expect(() => empty.first()).toThrow();
+  });
+
+  it('accepts non-iterable records', () => {
+    const qr = new QueryResults({ id: 1 } as any, null);
+    expect(qr.first()).toEqual({ id: 1 });
+    expect(qr.size()).toBe(1);
+  });
+
+  it('accepts iterable and array-like inputs', () => {
+    const fromSet = new QueryResults(new Set([{ id: 1 }, { id: 2 }]) as any, null);
+    expect(fromSet.size()).toBe(2);
+    const arrayLike = { 0: { id: 3 }, length: 1 } as any;
+    const fromArrayLike = new QueryResults(arrayLike, null);
+    expect(fromArrayLike.first()).toEqual({ id: 3 });
+    const fromNull = new QueryResults(undefined as any, null);
+    expect(fromNull.size()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- handle arrays, iterables, array-like objects, and single records in QueryResults constructor
- cover QueryResults with tests for iterable and array-like inputs
- document change in changelog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- --hookTimeout=30000`


------
https://chatgpt.com/codex/tasks/task_e_68be480fcc1483219b7028cf2044d2c4