### PR TITLE
Fix QueryResults.forEach to iterate all pages

### DIFF
--- a/changelog/2025-09-23-0600pm-query-results-foreach.md
+++ b/changelog/2025-09-23-0600pm-query-results-foreach.md
@@ -1,0 +1,14 @@
+# Change: ensure QueryResults.forEach iterates all pages
+
+- Date: 2025-09-23 06:00 PM PT
+- Author/Agent: ChatGPT
+- Scope: lib
+- Type: fix
+- Summary:
+  - Route QueryResults.forEach through forEachAll so callbacks see every remote page.
+  - Support optional thisArg binding and promise callbacks for QueryResults.forEach.
+  - Extend tests to cover QueryResultsPromise.forEach behavior and early termination.
+- Impact:
+  - Behavior change: QueryResults.forEach now fetches additional pages automatically.
+- Follow-ups:
+  - None


### PR DESCRIPTION
## Summary
- route `QueryResults.forEach` through `forEachAll` so callbacks iterate every remote page and preserve `thisArg` binding support
- keep page-scoped traversal via `forEachOnPage` while deferring to the array implementation
- expand query results tests to cover the new `forEach` semantics and document the change in the changelog

## Testing
- npm run lint
- npm run typecheck
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d34155e76c8321800a354bbfa13931