### PR TITLE
docs: document update query usage example

### DIFF
--- a/changelog/2025-09-29-0436am-update-query-example.md
+++ b/changelog/2025-09-29-0436am-update-query-example.md
@@ -1,0 +1,13 @@
+# Change: Document update query example
+
+- Date: 2025-09-29 04:36 AM UTC
+- Author/Agent: ChatGPT-5-Codex
+- Scope: docs
+- Type: docs
+- Summary:
+  - Added an update query builder example to the README usage guide.
+  - Clarified that `.update()` returns the count of modified rows.
+- Impact:
+  - Documentation only; no runtime behavior changes.
+- Follow-ups:
+  - None

--- a/changelog/2025-09-29-0508am-update-query-example.md
+++ b/changelog/2025-09-29-0508am-update-query-example.md
@@ -1,0 +1,13 @@
+# Change: add runnable update query example
+
+- Date: 2025-09-29 05:08 AM PT
+- Author/Agent: OpenAI ChatGPT
+- Scope: examples
+- Type: docs
+- Summary:
+  - add a runnable update example under examples/query
+  - reference the new example from the README update snippet
+- Impact:
+  - documentation improvement only
+- Follow-ups:
+  - none

--- a/docs/README.md
+++ b/docs/README.md
@@ -366,7 +366,29 @@ await db.cascade('permissions:Permission(roleId, id)').save('Role', {
 });
 ```
 
-### 3) Delete (by primary key)
+### 3) Update existing rows
+
+```ts
+import { onyx, eq } from '@onyx.dev/onyx-database';
+
+const db = onyx.init();
+
+const updatedCount = await db
+  .from('User')
+  .where(eq('id', 'user_123'))
+  .setUpdates({ status: 'inactive' })
+  .update();
+
+console.log(`Updated ${updatedCount} record(s).`);
+```
+
+`.update()` returns the number of rows that were modified. Call `.setUpdates()`
+before `.update()` to provide the fields you want to change.
+
+A runnable version of this snippet lives at
+[`examples/query/update.ts`](../examples/query/update.ts).
+
+### 4) Delete (by primary key)
 
 ```ts
 import { onyx } from '@onyx.dev/onyx-database';
@@ -382,7 +404,7 @@ await db.delete('Role', 'role_temp', { relationships: ['rolePermissions'] });
 await db.cascade('rolePermissions').delete('Role', 'role_temp');
 ```
 
-### 4) Delete using query
+### 5) Delete using query
 
 ```ts
 import { onyx } from '@onyx.dev/onyx-database';
@@ -396,7 +418,7 @@ const delCount = await db
 
 ```
 
-### 5) Documents API (binary assets)
+### 6) Documents API (binary assets)
 
 ```ts
 import { onyx, type OnyxDocument } from '@onyx.dev/onyx-database';

--- a/examples/query/update.ts
+++ b/examples/query/update.ts
@@ -6,13 +6,13 @@ import { Schema, tables } from 'onyx/types';
 async function main(): Promise<void> {
   const db = onyx.init<Schema>();
 
-  const updated = await db
+  const updatedCount = await db
     .from(tables.User)
     .where(eq('id', 'example-user-1'))
     .setUpdates({ isActive: false })
-    .update() as number;
+    .update();
 
-  console.log(`Updated ${updated} record(s).`); //Updated 1 record(s).
+  console.log(`Updated ${updatedCount} record(s).`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- add an update query builder example to the README usage section
- clarify that `.update()` returns the number of modified rows
- add a runnable example in `examples/query/update.ts` referenced from the docs

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da0c5c62848321a06d97af81c9a83e